### PR TITLE
Map RIGHT ALT/LANGUAGE SWITCH keys to SUPER key

### DIFF
--- a/app/src/main/java/com/gaurav/avnc/ui/vnc/Dispatcher.kt
+++ b/app/src/main/java/com/gaurav/avnc/ui/vnc/Dispatcher.kt
@@ -9,11 +9,9 @@
 package com.gaurav.avnc.ui.vnc
 
 import android.graphics.PointF
-import android.view.KeyEvent
 import com.gaurav.avnc.viewmodel.VncViewModel
 import com.gaurav.avnc.vnc.Messenger
 import com.gaurav.avnc.vnc.PointerButton
-import com.gaurav.avnc.vnc.XKeySym
 import kotlin.math.abs
 
 /**
@@ -104,20 +102,6 @@ class Dispatcher(private val activity: VncActivity) {
         }
     }
 
-    private fun getMappedKeySym(keySym: Int, keyCode: Int): Int {
-        if (keySym == 0) {
-            if (keyCode == KeyEvent.KEYCODE_LANGUAGE_SWITCH && prefs.input.kmLanguageSwitchToSuper)
-                return XKeySym.XK_Super_L
-
-            return 0
-        } else {
-            if (keySym == XKeySym.XK_Alt_R && prefs.input.kmRightAltToSuper)
-                return XKeySym.XK_Super_L
-        }
-
-        return keySym
-    }
-
 
     /**************************************************************************
      * Event receivers
@@ -138,15 +122,7 @@ class Dispatcher(private val activity: VncActivity) {
             endDrag(p)
     }
 
-    fun onXKeySym(keySym: Int, isDown: Boolean, keyCode: Int = 0): Boolean {
-        val mappedKeySym = getMappedKeySym(keySym, keyCode)
-
-        if (mappedKeySym == 0)
-            return false
-
-        messenger.sendKey(mappedKeySym, isDown)
-        return true
-    }
+    fun onXKeySym(keySym: Int, isDown: Boolean) = messenger.sendKey(keySym, isDown)
 
     fun onMouseButtonDown(button: PointerButton, p: PointF) = doPointerButtonDown(button, p)
     fun onMouseButtonUp(button: PointerButton, p: PointF) = doPointerButtonUp(button, p)

--- a/app/src/main/java/com/gaurav/avnc/ui/vnc/Dispatcher.kt
+++ b/app/src/main/java/com/gaurav/avnc/ui/vnc/Dispatcher.kt
@@ -9,9 +9,11 @@
 package com.gaurav.avnc.ui.vnc
 
 import android.graphics.PointF
+import android.view.KeyEvent
 import com.gaurav.avnc.viewmodel.VncViewModel
 import com.gaurav.avnc.vnc.Messenger
 import com.gaurav.avnc.vnc.PointerButton
+import com.gaurav.avnc.vnc.XKeySym
 import kotlin.math.abs
 
 /**
@@ -102,6 +104,20 @@ class Dispatcher(private val activity: VncActivity) {
         }
     }
 
+    private fun getMappedKeySym(keySym: Int, keyCode: Int): Int {
+        if (keySym == 0) {
+            if (keyCode == KeyEvent.KEYCODE_LANGUAGE_SWITCH && prefs.input.kmLanguageSwitchToSuper)
+                return XKeySym.XK_Super_L
+
+            return 0
+        } else {
+            if (keySym == XKeySym.XK_Alt_R && prefs.input.kmRightAltToSuper)
+                return XKeySym.XK_Super_L
+        }
+
+        return keySym
+    }
+
 
     /**************************************************************************
      * Event receivers
@@ -122,7 +138,15 @@ class Dispatcher(private val activity: VncActivity) {
             endDrag(p)
     }
 
-    fun onXKeySym(keySym: Int, isDown: Boolean) = messenger.sendKey(keySym, isDown)
+    fun onXKeySym(keySym: Int, isDown: Boolean, keyCode: Int = 0): Boolean {
+        val mappedKeySym = getMappedKeySym(keySym, keyCode)
+
+        if (mappedKeySym == 0)
+            return false
+
+        messenger.sendKey(mappedKeySym, isDown)
+        return true
+    }
 
     fun onMouseButtonDown(button: PointerButton, p: PointF) = doPointerButtonDown(button, p)
     fun onMouseButtonUp(button: PointerButton, p: PointF) = doPointerButtonUp(button, p)

--- a/app/src/main/java/com/gaurav/avnc/ui/vnc/KeyHandler.kt
+++ b/app/src/main/java/com/gaurav/avnc/ui/vnc/KeyHandler.kt
@@ -162,7 +162,7 @@ class KeyHandler(private val dispatcher: Dispatcher, private val compatMode: Boo
      */
     private fun emitForAndroidKeyCode(keyCode: Int, isDown: Boolean): Boolean {
         val keySym = XKeySymAndroid.getKeySymForAndroidKeyCode(keyCode)
-        return emit(keySym, isDown)
+        return emit(keySym, isDown, keyCode)
     }
 
     /**
@@ -197,12 +197,11 @@ class KeyHandler(private val dispatcher: Dispatcher, private val compatMode: Boo
     /**
      * Sends given [keySym] to [dispatcher].
      */
-    private fun emit(keySym: Int, isDown: Boolean): Boolean {
-        if (keySym == 0)
+    private fun emit(keySym: Int, isDown: Boolean, keyCode: Int = 0): Boolean {
+        if (keySym == 0 && keyCode == 0)
             return false
 
-        dispatcher.onXKeySym(keySym, isDown)
-        return true
+        return dispatcher.onXKeySym(keySym, isDown, keyCode)
     }
 
     /************************************************************************************

--- a/app/src/main/java/com/gaurav/avnc/ui/vnc/KeyHandler.kt
+++ b/app/src/main/java/com/gaurav/avnc/ui/vnc/KeyHandler.kt
@@ -10,7 +10,10 @@ package com.gaurav.avnc.ui.vnc
 
 import android.os.Build
 import android.view.KeyEvent
+import com.gaurav.avnc.util.AppPreferences
+import com.gaurav.avnc.vnc.XKeySym
 import com.gaurav.avnc.vnc.XKeySymAndroid
+import com.gaurav.avnc.vnc.XKeySymAndroid.updateKeyMap
 import com.gaurav.avnc.vnc.XKeySymUnicode
 
 /**
@@ -74,7 +77,12 @@ import com.gaurav.avnc.vnc.XKeySymUnicode
  * [X Windows System Protocol](https://www.x.org/releases/X11R7.7/doc/xproto/x11protocol.html#keysym_encoding)
  *
  */
-class KeyHandler(private val dispatcher: Dispatcher, private val compatMode: Boolean) {
+class KeyHandler(private val dispatcher: Dispatcher, private val compatMode: Boolean, prefs: AppPreferences) {
+
+    init {
+        if (prefs.input.kmLanguageSwitchToSuper) updateKeyMap(KeyEvent.KEYCODE_LANGUAGE_SWITCH, XKeySym.XK_Super_L)
+        if (prefs.input.kmRightAltToSuper) updateKeyMap(KeyEvent.KEYCODE_ALT_RIGHT, XKeySym.XK_Super_L)
+    }
 
     /**
      * Shortcut to send both up & down events. Useful for Virtual Keys.
@@ -162,7 +170,7 @@ class KeyHandler(private val dispatcher: Dispatcher, private val compatMode: Boo
      */
     private fun emitForAndroidKeyCode(keyCode: Int, isDown: Boolean): Boolean {
         val keySym = XKeySymAndroid.getKeySymForAndroidKeyCode(keyCode)
-        return emit(keySym, isDown, keyCode)
+        return emit(keySym, isDown)
     }
 
     /**
@@ -197,11 +205,12 @@ class KeyHandler(private val dispatcher: Dispatcher, private val compatMode: Boo
     /**
      * Sends given [keySym] to [dispatcher].
      */
-    private fun emit(keySym: Int, isDown: Boolean, keyCode: Int = 0): Boolean {
-        if (keySym == 0 && keyCode == 0)
+    private fun emit(keySym: Int, isDown: Boolean): Boolean {
+        if (keySym == 0)
             return false
 
-        return dispatcher.onXKeySym(keySym, isDown, keyCode)
+        dispatcher.onXKeySym(keySym, isDown)
+        return true
     }
 
     /************************************************************************************

--- a/app/src/main/java/com/gaurav/avnc/ui/vnc/VncActivity.kt
+++ b/app/src/main/java/com/gaurav/avnc/ui/vnc/VncActivity.kt
@@ -65,7 +65,7 @@ class VncActivity : AppCompatActivity() {
     lateinit var binding: ActivityVncBinding
     private val dispatcher by lazy { Dispatcher(this) }
     val touchHandler by lazy { TouchHandler(viewModel, dispatcher) }
-    val keyHandler by lazy { KeyHandler(dispatcher, profile.keyCompatMode) }
+    val keyHandler by lazy { KeyHandler(dispatcher, profile.keyCompatMode, viewModel.pref) }
     private val virtualKeys by lazy { VirtualKeys(this) }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/gaurav/avnc/util/AppPreferences.kt
+++ b/app/src/main/java/com/gaurav/avnc/util/AppPreferences.kt
@@ -54,6 +54,9 @@ class AppPreferences(context: Context) {
         val vkShowAll; get() = prefs.getBoolean("vk_show_all", false)
 
         val mousePassthrough; get() = prefs.getBoolean("mouse_passthrough", true)
+
+        val kmLanguageSwitchToSuper; get() = prefs.getBoolean("km_language_switch_to_super", false)
+        val kmRightAltToSuper; get() = prefs.getBoolean("km_right_alt_to_super", false)
     }
 
     inner class Server {

--- a/app/src/main/java/com/gaurav/avnc/vnc/XKeySymAndroid.kt
+++ b/app/src/main/java/com/gaurav/avnc/vnc/XKeySymAndroid.kt
@@ -26,6 +26,11 @@ object XKeySymAndroid {
             return 0
     }
 
+    fun updateKeyMap(keyCode: Int, xKeySym: Int) {
+        if (keyCode >= 0 && keyCode < AndroidKeyCodeToXKeySym.size)
+            AndroidKeyCodeToXKeySym[keyCode] = xKeySym
+    }
+
     /**
      * Lookup table for X KeySym.
      *
@@ -198,10 +203,6 @@ object XKeySymAndroid {
             0,                                  //  KEYCODE_NUMPAD_LEFT_PAREN = 162
             0,                                  //  KEYCODE_NUMPAD_RIGHT_PAREN = 163
             XKeySym.XF86XK_AudioMute,           //  KEYCODE_VOLUME_MUTE = 164
-
-            /*  We currently have no mapping for rest of the key codes.
-                So these are commented to reduce the lookup table size.
-
             0,                                  //  KEYCODE_INFO = 165
             0,                                  //  KEYCODE_CHANNEL_UP = 166
             0,                                  //  KEYCODE_CHANNEL_DOWN = 167
@@ -242,6 +243,10 @@ object XKeySymAndroid {
             0,                                  //  KEYCODE_BUTTON_15 = 202
             0,                                  //  KEYCODE_BUTTON_16 = 203
             0,                                  //  KEYCODE_LANGUAGE_SWITCH = 204
+
+            /*  We currently have no mapping for rest of the key codes.
+                So these are commented to reduce the lookup table size.
+
             0,                                  //  KEYCODE_MANNER_MODE = 205
             0,                                  //  KEYCODE_3D_MODE = 206
             0,                                  //  KEYCODE_CONTACTS = 207

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -96,7 +96,7 @@
     <string name="pref_viewer">Viewer</string>
     <string name="pref_viewer_summary">Picture-in-Picture, Zoom</string>
     <string name="pref_input">Input</string>
-    <string name="pref_input_summary">Gestures, Mouse, Virtual keys</string>
+    <string name="pref_input_summary">Gestures, Mouse, Virtual keys, Key Mappings</string>
     <string name="pref_servers">Servers</string>
     <string name="pref_server_summary">Discovery, Credentials</string>
     <string name="pref_tools">Tools</string>
@@ -135,6 +135,9 @@
     <string name="pref_vk">Virtual Keys</string>
     <string name="pref_vk_show_all">Show all keys</string>
     <string name="pref_vk_open_with_keyboard">Show when Keyboard is open</string>
+    <string name="pref_km">Keyboard Mappings</string>
+    <string name="pref_km_right_alt_to_super">Right Alt to Super</string>
+    <string name="pref_km_language_switch_to_super">Language Switch to Super</string>
     <string name="pref_fullscreen">Use Fullscreen</string>
     <string name="pref_enable_pip">Enable Picture-in-Picture</string>
     <string name="pref_toolbar">Toolbar</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -96,7 +96,7 @@
     <string name="pref_viewer">Viewer</string>
     <string name="pref_viewer_summary">Picture-in-Picture, Zoom</string>
     <string name="pref_input">Input</string>
-    <string name="pref_input_summary">Gestures, Mouse, Virtual keys, Key Mappings</string>
+    <string name="pref_input_summary">Gestures, Mouse, Virtual keys</string>
     <string name="pref_servers">Servers</string>
     <string name="pref_server_summary">Discovery, Credentials</string>
     <string name="pref_tools">Tools</string>
@@ -135,7 +135,7 @@
     <string name="pref_vk">Virtual Keys</string>
     <string name="pref_vk_show_all">Show all keys</string>
     <string name="pref_vk_open_with_keyboard">Show when Keyboard is open</string>
-    <string name="pref_km">Keyboard Mappings</string>
+    <string name="pref_km">Key Mappings</string>
     <string name="pref_km_right_alt_to_super">Right Alt to Super</string>
     <string name="pref_km_language_switch_to_super">Language Switch to Super</string>
     <string name="pref_fullscreen">Use Fullscreen</string>

--- a/app/src/main/res/xml/pref_input.xml
+++ b/app/src/main/res/xml/pref_input.xml
@@ -96,8 +96,9 @@
             app:key="vk_show_all"
             app:title="@string/pref_vk_show_all" />
     </PreferenceCategory>
+
     <PreferenceCategory
-        app:icon="@drawable/ic_keyboard_mini"
+        app:icon="@drawable/ic_keyboard"
         app:title="@string/pref_km">
 
         <SwitchPreference

--- a/app/src/main/res/xml/pref_input.xml
+++ b/app/src/main/res/xml/pref_input.xml
@@ -96,5 +96,19 @@
             app:key="vk_show_all"
             app:title="@string/pref_vk_show_all" />
     </PreferenceCategory>
+    <PreferenceCategory
+        app:icon="@drawable/ic_keyboard_mini"
+        app:title="@string/pref_km">
+
+        <SwitchPreference
+            app:defaultValue="false"
+            app:key="km_right_alt_to_super"
+            app:title="@string/pref_km_right_alt_to_super" />
+
+        <SwitchPreference
+            app:defaultValue="false"
+            app:key="km_language_switch_to_super"
+            app:title="@string/pref_km_language_switch_to_super" />
+    </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
In this PR, I added 2 options for mapping RIGHT ALT key to SUPER key and LANGUAGE SWITCH key to SUPER key.
- I think this is useful SUPER key can not be listened.
- The LANGAUGE SWITCH key is specifically for Samsung keyboard cover which is between SPACE and RIGHT ALT.