### PR TITLE
TouchHandler: Make onGenericMotionEvent handle stylus and mouse events

### DIFF
--- a/app/src/main/java/com/gaurav/avnc/ui/vnc/TouchHandler.kt
+++ b/app/src/main/java/com/gaurav/avnc/ui/vnc/TouchHandler.kt
@@ -55,7 +55,10 @@ class TouchHandler(private val viewModel: VncViewModel, private val dispatcher: 
         return gestureDetector.onTouchEvent(event)
     }
 
-    fun onGenericMotionEvent(event: MotionEvent) = handleMouseEvent(event)
+    fun onGenericMotionEvent(event: MotionEvent): Boolean {
+        // Event could be from either a stylus (hovering) or a mouse
+        return handleStylusEvent(event) || handleMouseEvent(event)
+    }
 
     override fun onDown(e: MotionEvent): Boolean {
         frameScroller.stop()


### PR DESCRIPTION
Previously, `onGenericMotionEvent` only passed events to `handleMouseEvent`.

Stylus hover move events triggered `onGenericMotionEvent`, so this callback should handle stylus events, too.

Fixes #25.