### PR TITLE
Add preference to hide Android system cursor

### DIFF
--- a/app/src/main/java/com/gaurav/avnc/ui/prefs/PrefsActivity.kt
+++ b/app/src/main/java/com/gaurav/avnc/ui/prefs/PrefsActivity.kt
@@ -92,7 +92,21 @@ class PrefsActivity : AppCompatActivity(), PreferenceFragmentCompat.OnPreference
         }
     }
 
-    @Keep class Input : PrefFragment(R.xml.pref_input)
+    @Keep class Input : PrefFragment(R.xml.pref_input) {
+        override fun onCreate(savedInstanceState: Bundle?) {
+            super.onCreate(savedInstanceState)
+
+            val canChangePtrIcon = Build.VERSION.SDK_INT >= 24
+
+            if (!canChangePtrIcon) {
+                findPreference<SwitchPreference>("hide_local_cursor")!!.apply {
+                    isEnabled = false
+                    summary = getString(R.string.msg_ptr_hiding_not_supported)
+                }
+            }
+        }
+    }
+
     @Keep class Server : PrefFragment(R.xml.pref_server)
     @Keep class Tools : PrefFragment(R.xml.pref_tools)
     @Keep class Experimental : PrefFragment(R.xml.pref_experimental)

--- a/app/src/main/java/com/gaurav/avnc/ui/vnc/FrameView.kt
+++ b/app/src/main/java/com/gaurav/avnc/ui/vnc/FrameView.kt
@@ -11,9 +11,11 @@ package com.gaurav.avnc.ui.vnc
 import android.annotation.SuppressLint
 import android.content.Context
 import android.opengl.GLSurfaceView
+import android.os.Build
 import android.util.AttributeSet
 import android.view.KeyEvent
 import android.view.MotionEvent
+import android.view.PointerIcon
 import android.view.inputmethod.BaseInputConnection
 import android.view.inputmethod.EditorInfo
 import com.gaurav.avnc.ui.vnc.gl.Renderer
@@ -70,13 +72,16 @@ class FrameView(context: Context?, attrs: AttributeSet? = null) : GLSurfaceView(
         setEGLContextClientVersion(2)
         setRenderer(Renderer(viewModel))
         renderMode = RENDERMODE_WHEN_DIRTY
+
+        // Hide local cursor if requested and supported
+        if (Build.VERSION.SDK_INT >= 24 && viewModel.pref.input.hideLocalCursor)
+            pointerIcon = PointerIcon.getSystemIcon(context, PointerIcon.TYPE_NULL)
     }
 
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
         super.onSizeChanged(w, h, oldw, oldh)
         frameState.setViewportSize(w.toFloat(), h.toFloat())
     }
-
 
     override fun onCreateInputConnection(outAttrs: EditorInfo): InputConnection {
         outAttrs.imeOptions = outAttrs.imeOptions or

--- a/app/src/main/java/com/gaurav/avnc/util/AppPreferences.kt
+++ b/app/src/main/java/com/gaurav/avnc/util/AppPreferences.kt
@@ -54,6 +54,7 @@ class AppPreferences(context: Context) {
         val vkShowAll; get() = prefs.getBoolean("vk_show_all", false)
 
         val mousePassthrough; get() = prefs.getBoolean("mouse_passthrough", true)
+        val hideLocalCursor; get() = prefs.getBoolean("hide_local_cursor", false)
 
         val kmLanguageSwitchToSuper; get() = prefs.getBoolean("km_language_switch_to_super", false)
         val kmRightAltToSuper; get() = prefs.getBoolean("km_right_alt_to_super", false)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,6 +57,7 @@
     <string name="msg_server_profile_added">Server added.</string>
     <string name="msg_server_profile_deleted">Server deleted.</string>
     <string name="msg_pip_not_supported">Picture-in-Picture is not supported on this device</string>
+    <string name="msg_ptr_hiding_not_supported">Hiding cursor is not supported on this device</string>
     <string name="msg_loading">Loading …</string>
     <string name="msg_imported">Imported Successfully</string>
     <string name="msg_exported">Exported Successfully</string>
@@ -132,6 +133,7 @@
     <string name="pref_mouse_passthrough">Mouse Passthrough</string>
     <string name="pref_mouse_passthrough_summary_off">Mouse events are used locally for gestures</string>
     <string name="pref_mouse_passthrough_summary_on">Mouse events are sent directly to Server</string>
+    <string name="pref_hide_local_cursor">Hide Local (Android) Cursor</string>
     <string name="pref_vk">Virtual Keys</string>
     <string name="pref_vk_show_all">Show all keys</string>
     <string name="pref_vk_open_with_keyboard">Show when Keyboard is open</string>

--- a/app/src/main/res/xml/pref_input.xml
+++ b/app/src/main/res/xml/pref_input.xml
@@ -80,6 +80,11 @@
             app:summaryOff="@string/pref_mouse_passthrough_summary_off"
             app:summaryOn="@string/pref_mouse_passthrough_summary_on"
             app:title="@string/pref_mouse_passthrough" />
+
+        <SwitchPreference
+            app:defaultValue="false"
+            app:key="hide_local_cursor"
+            app:title="@string/pref_hide_local_cursor" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
## Summary
 * Adds a new preference that hides the default system cursor (on by default)
 * Requires Android N or above &mdash; includes API level checks (only tested on a more-recent Android device)
 * Should fix #28

![](https://user-images.githubusercontent.com/46334387/146498606-13af2e8c-8a6b-4a59-8395-519207ae6086.jpg)
![](https://user-images.githubusercontent.com/46334387/146498658-076d2965-870c-4ea2-838e-549d69040314.jpg)


## TODO
 * [ ] Check that the API level checks prevent things from breaking if `Build.VERSION.SDK_INT ≤ Build.VERSION_CODES.N`