### PR TITLE
Add option to remap back press from mouse device

### DIFF
--- a/app/src/main/java/com/gaurav/avnc/ui/vnc/TouchHandler.kt
+++ b/app/src/main/java/com/gaurav/avnc/ui/vnc/TouchHandler.kt
@@ -62,9 +62,19 @@ class TouchHandler(private val viewModel: VncViewModel, private val dispatcher: 
     //Temporary workaround for emulating mouse right-click until
     //pointer-position is implemented in VncClient
     private var lastHoverPoint = PointF()
-    fun fakeMouseRightClick(isDown: Boolean) {
-        if (isDown) dispatcher.onMouseButtonDown(PointerButton.Right, lastHoverPoint)
-        else dispatcher.onMouseButtonUp(PointerButton.Right, lastHoverPoint)
+    private var mouseBack = viewModel.pref.input.mouseBack
+    fun fakeMouseClick(isDown: Boolean) {
+        if (mouseBack == "none")
+            return
+
+        var buttonToMap = PointerButton.Right;
+        when (mouseBack) {
+            "right" -> buttonToMap = PointerButton.Right
+            "middle" -> buttonToMap = PointerButton.Middle
+        }
+
+        if (isDown) dispatcher.onMouseButtonDown(buttonToMap, lastHoverPoint)
+        else dispatcher.onMouseButtonUp(buttonToMap, lastHoverPoint)
     }
 
     /****************************************************************************************

--- a/app/src/main/java/com/gaurav/avnc/ui/vnc/TouchHandler.kt
+++ b/app/src/main/java/com/gaurav/avnc/ui/vnc/TouchHandler.kt
@@ -64,7 +64,7 @@ class TouchHandler(private val viewModel: VncViewModel, private val dispatcher: 
     private var lastHoverPoint = PointF()
     private var mouseBack = viewModel.pref.input.mouseBack
     fun fakeMouseClick(isDown: Boolean) {
-        if (mouseBack == "none")
+        if (mouseBack == "default")
             return
 
         var buttonToMap = PointerButton.Right;

--- a/app/src/main/java/com/gaurav/avnc/ui/vnc/TouchHandler.kt
+++ b/app/src/main/java/com/gaurav/avnc/ui/vnc/TouchHandler.kt
@@ -63,9 +63,9 @@ class TouchHandler(private val viewModel: VncViewModel, private val dispatcher: 
     //pointer-position is implemented in VncClient
     private var lastHoverPoint = PointF()
     private var mouseBack = viewModel.pref.input.mouseBack
-    fun fakeMouseClick(isDown: Boolean) {
+    fun fakeMouseClick(isDown: Boolean): Boolean {
         if (mouseBack == "default")
-            return
+            return false
 
         var buttonToMap = PointerButton.Right;
         when (mouseBack) {
@@ -75,6 +75,8 @@ class TouchHandler(private val viewModel: VncViewModel, private val dispatcher: 
 
         if (isDown) dispatcher.onMouseButtonDown(buttonToMap, lastHoverPoint)
         else dispatcher.onMouseButtonUp(buttonToMap, lastHoverPoint)
+
+        return true
     }
 
     /****************************************************************************************

--- a/app/src/main/java/com/gaurav/avnc/ui/vnc/VncActivity.kt
+++ b/app/src/main/java/com/gaurav/avnc/ui/vnc/VncActivity.kt
@@ -321,10 +321,8 @@ class VncActivity : AppCompatActivity() {
         //need Mouse right-click events. It is hardcoded to act as back-press, without
         //giving apps a chance to handle it. For better or worse, they set the 'source'
         //for such key events to Mouse, enabling the following workarounds.
-        val device = InputDevice.getDevice(keyEvent.deviceId)
-        if (Build.VERSION.SDK_INT >= 23 &&
-            keyEvent.keyCode == KeyEvent.KEYCODE_BACK &&
-            device.sources or InputDevice.SOURCE_MOUSE == device.sources) {
+        if (keyEvent.keyCode == KeyEvent.KEYCODE_BACK &&
+            InputDevice.getDevice(keyEvent.deviceId).supportsSource(InputDevice.SOURCE_MOUSE)) {
 
             val isDown = keyEvent.action == KeyEvent.ACTION_DOWN
             touchHandler.fakeMouseClick(isDown)

--- a/app/src/main/java/com/gaurav/avnc/ui/vnc/VncActivity.kt
+++ b/app/src/main/java/com/gaurav/avnc/ui/vnc/VncActivity.kt
@@ -321,10 +321,10 @@ class VncActivity : AppCompatActivity() {
         //need Mouse right-click events. It is hardcoded to act as back-press, without
         //giving apps a chance to handle it. For better or worse, they set the 'source'
         //for such key events to Mouse, enabling the following workarounds.
+        val device = InputDevice.getDevice(keyEvent.deviceId)
         if (Build.VERSION.SDK_INT >= 23 &&
             keyEvent.keyCode == KeyEvent.KEYCODE_BACK &&
-            (keyEvent.source == InputDevice.SOURCE_MOUSE ||
-             keyEvent.deviceId > 0 && keyEvent.scanCode == 0)) {
+            device.sources or InputDevice.SOURCE_MOUSE == device.sources) {
 
             val isDown = keyEvent.action == KeyEvent.ACTION_DOWN
             touchHandler.fakeMouseClick(isDown)

--- a/app/src/main/java/com/gaurav/avnc/ui/vnc/VncActivity.kt
+++ b/app/src/main/java/com/gaurav/avnc/ui/vnc/VncActivity.kt
@@ -323,10 +323,11 @@ class VncActivity : AppCompatActivity() {
         //for such key events to Mouse, enabling the following workarounds.
         if (Build.VERSION.SDK_INT >= 23 &&
             keyEvent.keyCode == KeyEvent.KEYCODE_BACK &&
-            keyEvent.source == InputDevice.SOURCE_MOUSE) {
+            (keyEvent.source == InputDevice.SOURCE_MOUSE ||
+             keyEvent.deviceId > 0 && keyEvent.scanCode == 0)) {
 
             val isDown = keyEvent.action == KeyEvent.ACTION_DOWN
-            touchHandler.fakeMouseRightClick(isDown)
+            touchHandler.fakeMouseClick(isDown)
             return true
         }
 

--- a/app/src/main/java/com/gaurav/avnc/ui/vnc/VncActivity.kt
+++ b/app/src/main/java/com/gaurav/avnc/ui/vnc/VncActivity.kt
@@ -325,8 +325,7 @@ class VncActivity : AppCompatActivity() {
             InputDevice.getDevice(keyEvent.deviceId).supportsSource(InputDevice.SOURCE_MOUSE)) {
 
             val isDown = keyEvent.action == KeyEvent.ACTION_DOWN
-            touchHandler.fakeMouseClick(isDown)
-            return true
+            return touchHandler.fakeMouseClick(isDown)
         }
 
         return false

--- a/app/src/main/java/com/gaurav/avnc/util/AppPreferences.kt
+++ b/app/src/main/java/com/gaurav/avnc/util/AppPreferences.kt
@@ -54,6 +54,7 @@ class AppPreferences(context: Context) {
 
         val mousePassthrough; get() = prefs.getBoolean("mouse_passthrough", true)
         val hideLocalCursor; get() = prefs.getBoolean("hide_local_cursor", false)
+        val mouseBack; get() = prefs.getString("mouse_back", "right")!!
 
         val kmLanguageSwitchToSuper; get() = prefs.getBoolean("km_language_switch_to_super", false)
         val kmRightAltToSuper; get() = prefs.getBoolean("km_right_alt_to_super", false)

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -111,12 +111,12 @@
     </string-array>
 
     <string-array name="mouse_back_action_entries">
-        <item>@string/pref_mouse_back_action_none</item>
+        <item>@string/pref_mouse_back_action_default</item>
         <item>@string/pref_mouse_back_action_right</item>
         <item>@string/pref_mouse_back_action_middle</item>
     </string-array>
     <string-array name="mouse_back_action_values">
-        <item>none</item>
+        <item>default</item>
         <item>right</item>
         <item>middle</item>
     </string-array>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -109,4 +109,15 @@
         <item>pan</item>
         <item>remote-scroll</item>
     </string-array>
+
+    <string-array name="mouse_back_action_entries">
+        <item>@string/pref_mouse_back_action_none</item>
+        <item>@string/pref_mouse_back_action_right</item>
+        <item>@string/pref_mouse_back_action_middle</item>
+    </string-array>
+    <string-array name="mouse_back_action_values">
+        <item>none</item>
+        <item>right</item>
+        <item>middle</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -141,7 +141,7 @@
     <string name="pref_mouse_passthrough_summary_on">Send mouse events directly to server</string>
     <string name="pref_hide_local_cursor">Hide local (Android) pointer</string>
     <string name="pref_mouse_back">Back button</string>
-    <string name="pref_mouse_back_action_none">None</string>
+    <string name="pref_mouse_back_action_default">Default</string>
     <string name="pref_mouse_back_action_right">Right click</string>
     <string name="pref_mouse_back_action_middle">Middle click</string>
     <string name="pref_vk">Virtual keys</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -140,6 +140,10 @@
     <string name="pref_mouse_passthrough_summary_off">Use mouse events for local gestures</string>
     <string name="pref_mouse_passthrough_summary_on">Send mouse events directly to server</string>
     <string name="pref_hide_local_cursor">Hide local (Android) pointer</string>
+    <string name="pref_mouse_back">Map Mouse Back</string>
+    <string name="pref_mouse_back_action_none">None</string>
+    <string name="pref_mouse_back_action_right">Right Click</string>
+    <string name="pref_mouse_back_action_middle">Middle Click</string>
     <string name="pref_vk">Virtual keys</string>
     <string name="pref_vk_show_all">Show all keys</string>
     <string name="pref_vk_open_with_keyboard">Open with keyboard</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -140,10 +140,10 @@
     <string name="pref_mouse_passthrough_summary_off">Use mouse events for local gestures</string>
     <string name="pref_mouse_passthrough_summary_on">Send mouse events directly to server</string>
     <string name="pref_hide_local_cursor">Hide local (Android) pointer</string>
-    <string name="pref_mouse_back">Map Mouse Back</string>
+    <string name="pref_mouse_back">Back button</string>
     <string name="pref_mouse_back_action_none">None</string>
-    <string name="pref_mouse_back_action_right">Right Click</string>
-    <string name="pref_mouse_back_action_middle">Middle Click</string>
+    <string name="pref_mouse_back_action_right">Right click</string>
+    <string name="pref_mouse_back_action_middle">Middle click</string>
     <string name="pref_vk">Virtual keys</string>
     <string name="pref_vk_show_all">Show all keys</string>
     <string name="pref_vk_open_with_keyboard">Open with keyboard</string>

--- a/app/src/main/res/xml/pref_input.xml
+++ b/app/src/main/res/xml/pref_input.xml
@@ -93,6 +93,14 @@
             app:defaultValue="false"
             app:key="hide_local_cursor"
             app:title="@string/pref_hide_local_cursor" />
+
+        <ListPreference
+            app:defaultValue="right"
+            app:entries="@array/mouse_back_action_entries"
+            app:entryValues="@array/mouse_back_action_values"
+            app:key="mouse_back"
+            app:title="@string/pref_mouse_back"
+            app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
This add an option allows user map back press from mouse button to `None`, `Right Click`, `Middle Click`.
My the touchpad Samsung keyboard has an option to act "three finger tap" as back but key event source is keyboard, not mouse. So I added conditions: `keyEvent.deviceId > 0 && keyEvent.scanCode == 0` and not sure if it is the best way to handle. Please see this log for key event of different input:

<details>
<summary>KeyEvent</summary>
<pre>
- Samsung Touchpad: KeyEvent { action=ACTION_DOWN, keyCode=KEYCODE_BACK, scanCode=0, metaState=0, flags=0x8, repeatCount=0, eventTime=9993313, downTime=9993313, deviceId=15, source=0x101, displayId=0 }
- Samsung Keyboard: KeyEvent { action=ACTION_DOWN, keyCode=KEYCODE_BACK, scanCode=14, metaState=0, flags=0x8, repeatCount=0, eventTime=10804758, downTime=10804758, deviceId=14, source=0x101, displayId=-1 }
- Bluetooth Keyboard: KeyEvent { action=ACTION_DOWN, keyCode=KEYCODE_BACK, scanCode=14, metaState=META_NUM_LOCK_ON, flags=0x8, repeatCount=0, eventTime=12918543, downTime=12918543, deviceId=16, source=0x101, displayId=-1 }
- One Hand Operation +: KeyEvent { action=ACTION_DOWN, keyCode=KEYCODE_BACK, scanCode=0, metaState=0, flags=0xa, repeatCount=0, eventTime=10904112, downTime=10904112, deviceId=-1, source=0x101, displayId=-1 }
- Android Back: KeyEvent { action=ACTION_DOWN, keyCode=KEYCODE_BACK, scanCode=0, metaState=0, flags=0x48, repeatCount=0, eventTime=10993054, downTime=10993054, deviceId=-1, source=0x101, displayId=0 }
</pre>
</details>