### PR TITLE
Support three-finger gestures

### DIFF
--- a/app/src/androidTest/java/com/gaurav/avnc/ui/vnc/TouchHandlerTest.kt
+++ b/app/src/androidTest/java/com/gaurav/avnc/ui/vnc/TouchHandlerTest.kt
@@ -97,6 +97,16 @@ class TouchHandlerTest {
     }
 
     @Test
+    fun threeFingerTap() {
+        sendDown()
+        sendEvent(Factory.obtainPointerDownEvent(downEvent, testPoint, PointF(50f, 50f)))
+        sendEvent(Factory.obtainPointerUpEvent(downEvent, testPoint, PointF(50f, 50f)))
+        sendEvent(Factory.obtainPointerUpEvent(downEvent, testPoint, PointF(50f, 50f)))
+        sendUp()
+        verify { mockDispatcher.onTap3(testPoint) }
+    }
+
+    @Test
     fun longPress() {
         setupWithPref(dragEnabled = false)
         sendDown()

--- a/app/src/androidTest/java/com/gaurav/avnc/ui/vnc/TouchHandlerTest.kt
+++ b/app/src/androidTest/java/com/gaurav/avnc/ui/vnc/TouchHandlerTest.kt
@@ -36,6 +36,8 @@ import org.junit.Test
  * Although actual tests are very simple here, event creation & injection is quite complex.
  * But given the importance of gestures in AVNC and the complexity of [TouchHandler],
  * these tests are very valuable.
+ *
+ * TODO: add tests for 3-finger gestures
  */
 @SdkSuppress(minSdkVersion = 28)
 class TouchHandlerTest {
@@ -97,16 +99,6 @@ class TouchHandlerTest {
     }
 
     @Test
-    fun threeFingerTap() {
-        sendDown()
-        sendEvent(Factory.obtainPointerDownEvent(downEvent, testPoint, PointF(50f, 50f)))
-        sendEvent(Factory.obtainPointerUpEvent(downEvent, testPoint, PointF(50f, 50f)))
-        sendEvent(Factory.obtainPointerUpEvent(downEvent, testPoint, PointF(50f, 50f)))
-        sendUp()
-        verify { mockDispatcher.onTap3(testPoint) }
-    }
-
-    @Test
     fun longPress() {
         setupWithPref(dragEnabled = false)
         sendDown()
@@ -134,22 +126,6 @@ class TouchHandlerTest {
         sendEvent(Factory.obtainPointerDownEvent(downEvent, a1, b1))
         sendEvent(Factory.obtainMoveEvent(downEvent, a2, b2))
         verify { mockDispatcher.onSwipe2(a1, a2, 100f, 100f) }
-    }
-
-    @Test
-    fun swipe3Finger() {
-        val a1 = PointF(100f, 100f)
-        val a2 = PointF(200f, 200f)
-        val a3 = PointF(300f, 300f)
-        val b1 = PointF(400f, 400f)
-        val b2 = PointF(500f, 500f)
-        val b3 = PointF(600f, 600f)
-
-        sendDown(a1)
-        sendEvent(Factory.obtainPointerDownEvent(downEvent, a1, b1))
-        sendEvent(Factory.obtainMoveEvent(downEvent, a2, b2))
-        sendEvent(Factory.obtainMoveEvent(downEvent, a3, b3))
-        verify { mockDispatcher.onSwipe3(a1, a2, 100f, 100f) }
     }
 
     @Test

--- a/app/src/androidTest/java/com/gaurav/avnc/ui/vnc/TouchHandlerTest.kt
+++ b/app/src/androidTest/java/com/gaurav/avnc/ui/vnc/TouchHandlerTest.kt
@@ -137,6 +137,22 @@ class TouchHandlerTest {
     }
 
     @Test
+    fun swipe3Finger() {
+        val a1 = PointF(100f, 100f)
+        val a2 = PointF(200f, 200f)
+        val a3 = PointF(300f, 300f)
+        val b1 = PointF(400f, 400f)
+        val b2 = PointF(500f, 500f)
+        val b3 = PointF(600f, 600f)
+
+        sendDown(a1)
+        sendEvent(Factory.obtainPointerDownEvent(downEvent, a1, b1))
+        sendEvent(Factory.obtainMoveEvent(downEvent, a2, b2))
+        sendEvent(Factory.obtainMoveEvent(downEvent, a3, b3))
+        verify { mockDispatcher.onSwipe3(a1, a2, 100f, 100f) }
+    }
+
+    @Test
     fun scale() {
         val a1 = PointF(300f, 300f)
         val b1 = PointF(400f, 400f)

--- a/app/src/main/java/com/gaurav/avnc/ui/prefs/PrefsActivity.kt
+++ b/app/src/main/java/com/gaurav/avnc/ui/prefs/PrefsActivity.kt
@@ -117,6 +117,10 @@ class PrefsActivity : AppCompatActivity(), PreferenceFragmentCompat.OnPreference
                 enableIf { it["gesture_style"] != "touchpad" }
                 disabledStateSummary = getString(R.string.pref_gesture_action_move_pointer)
             }
+            findPreference<ListPreferenceEx>("gesture_swipe3")!!.apply {
+                enableIf { it["gesture_style"] == "touchpad" }
+                disabledStateSummary = getString(R.string.pref_gesture_action_move_pointer)
+            }
             findPreference<ListPreferenceEx>("gesture_long_press_swipe")!!.apply {
                 enableIf { it["gesture_long_press"] != "left-press" }
                 disabledStateSummary = getString(R.string.pref_gesture_action_none)

--- a/app/src/main/java/com/gaurav/avnc/ui/prefs/PrefsActivity.kt
+++ b/app/src/main/java/com/gaurav/avnc/ui/prefs/PrefsActivity.kt
@@ -14,7 +14,6 @@ import android.os.Build
 import android.os.Bundle
 import androidx.annotation.Keep
 import androidx.appcompat.app.AppCompatActivity
-import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreference
@@ -117,9 +116,6 @@ class PrefsActivity : AppCompatActivity(), PreferenceFragmentCompat.OnPreference
             findPreference<ListPreferenceEx>("gesture_swipe1")!!.apply {
                 enableIf { it["gesture_style"] != "touchpad" }
                 disabledStateSummary = getString(R.string.pref_gesture_action_move_pointer)
-            }
-            findPreference<ListPreference>("gesture_swipe3")!!.apply {
-                enableIf { it["gesture_style"] == "touchpad" }
             }
             findPreference<ListPreferenceEx>("gesture_long_press_swipe")!!.apply {
                 enableIf { it["gesture_long_press"] != "left-press" }

--- a/app/src/main/java/com/gaurav/avnc/ui/prefs/PrefsActivity.kt
+++ b/app/src/main/java/com/gaurav/avnc/ui/prefs/PrefsActivity.kt
@@ -14,6 +14,7 @@ import android.os.Build
 import android.os.Bundle
 import androidx.annotation.Keep
 import androidx.appcompat.app.AppCompatActivity
+import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreference
@@ -117,9 +118,8 @@ class PrefsActivity : AppCompatActivity(), PreferenceFragmentCompat.OnPreference
                 enableIf { it["gesture_style"] != "touchpad" }
                 disabledStateSummary = getString(R.string.pref_gesture_action_move_pointer)
             }
-            findPreference<ListPreferenceEx>("gesture_swipe3")!!.apply {
+            findPreference<ListPreference>("gesture_swipe3")!!.apply {
                 enableIf { it["gesture_style"] == "touchpad" }
-                disabledStateSummary = getString(R.string.pref_gesture_action_move_pointer)
             }
             findPreference<ListPreferenceEx>("gesture_long_press_swipe")!!.apply {
                 enableIf { it["gesture_long_press"] != "left-press" }

--- a/app/src/main/java/com/gaurav/avnc/ui/vnc/Dispatcher.kt
+++ b/app/src/main/java/com/gaurav/avnc/ui/vnc/Dispatcher.kt
@@ -69,6 +69,7 @@ class Dispatcher(private val activity: VncActivity) {
 
         val tap1Action = selectPointAction(gesturePref.tap1)
         val tap2Action = selectPointAction(gesturePref.tap2)
+        val tap3Action = selectPointAction(gesturePref.tap3)
         val doubleTapAction = selectPointAction(gesturePref.doubleTap)
         val longPressAction = selectPointAction(gesturePref.longPress)
 
@@ -134,6 +135,7 @@ class Dispatcher(private val activity: VncActivity) {
 
     fun onTap1(p: PointF) = config.tap1Action(p)
     fun onTap2(p: PointF) = config.tap2Action(p)
+    fun onTap3(p: PointF) = config.tap3Action(p)
     fun onDoubleTap(p: PointF) = config.doubleTapAction(p)
     fun onLongPress(p: PointF) = config.longPressAction(p)
 

--- a/app/src/main/java/com/gaurav/avnc/ui/vnc/Dispatcher.kt
+++ b/app/src/main/java/com/gaurav/avnc/ui/vnc/Dispatcher.kt
@@ -76,6 +76,7 @@ class Dispatcher(private val activity: VncActivity) {
         val swipe1Pref = if (gestureStyle == "touchpad") "move-pointer" else gesturePref.swipe1
         val swipe1Action = selectSwipeAction(swipe1Pref)
         val swipe2Action = selectSwipeAction(gesturePref.swipe2)
+        val swipe3Action = selectSwipeAction(gesturePref.swipe3)
         val doubleTapSwipeAction = selectSwipeAction(gesturePref.doubleTapSwipe)
         val longPressSwipeAction = selectSwipeAction(gesturePref.longPressSwipe)
         val flingAction = selectFlingAction()
@@ -141,6 +142,7 @@ class Dispatcher(private val activity: VncActivity) {
 
     fun onSwipe1(sp: PointF, cp: PointF, dx: Float, dy: Float) = config.swipe1Action(sp, cp, dx, dy)
     fun onSwipe2(sp: PointF, cp: PointF, dx: Float, dy: Float) = config.swipe2Action(sp, cp, dx, dy)
+    fun onSwipe3(sp: PointF, cp: PointF, dx: Float, dy: Float) = config.swipe3Action(sp, cp, dx, dy)
     fun onDoubleTapSwipe(sp: PointF, cp: PointF, dx: Float, dy: Float) = config.doubleTapSwipeAction(sp, cp, dx, dy)
     fun onLongPressSwipe(sp: PointF, cp: PointF, dx: Float, dy: Float) = config.longPressSwipeAction(sp, cp, dx, dy)
 

--- a/app/src/main/java/com/gaurav/avnc/ui/vnc/TouchHandler.kt
+++ b/app/src/main/java/com/gaurav/avnc/ui/vnc/TouchHandler.kt
@@ -199,7 +199,7 @@ class TouchHandler(private val frameView: FrameView, private val dispatcher: Dis
         override fun onMultiFingerTap(e: MotionEvent, fingerCount: Int) {
             when (fingerCount) {
                 2 -> dispatcher.onTap2(e.point())
-                // Taps by 3+ fingers are not exposed yet
+                3 -> dispatcher.onTap3(e.point()) // TODO: only for touchpad mode
             }
         }
 

--- a/app/src/main/java/com/gaurav/avnc/ui/vnc/TouchHandler.kt
+++ b/app/src/main/java/com/gaurav/avnc/ui/vnc/TouchHandler.kt
@@ -199,7 +199,7 @@ class TouchHandler(private val frameView: FrameView, private val dispatcher: Dis
         override fun onMultiFingerTap(e: MotionEvent, fingerCount: Int) {
             when (fingerCount) {
                 2 -> dispatcher.onTap2(e.point())
-                3 -> dispatcher.onTap3(e.point()) // TODO: only for touchpad mode
+                3 -> dispatcher.onTap3(e.point())
             }
         }
 

--- a/app/src/main/java/com/gaurav/avnc/ui/vnc/TouchHandler.kt
+++ b/app/src/main/java/com/gaurav/avnc/ui/vnc/TouchHandler.kt
@@ -225,6 +225,7 @@ class TouchHandler(private val frameView: FrameView, private val dispatcher: Dis
                 1 -> dispatcher.onSwipe1(startPoint, currentPoint, normalizedDx, normalizedDy)
                 2 -> if (swipeVsScale.shouldSwipe())
                     dispatcher.onSwipe2(startPoint, currentPoint, normalizedDx, normalizedDy)
+                3 -> dispatcher.onSwipe3(startPoint, currentPoint, normalizedDx, normalizedDy)
             }
         }
 

--- a/app/src/main/java/com/gaurav/avnc/util/AppPreferences.kt
+++ b/app/src/main/java/com/gaurav/avnc/util/AppPreferences.kt
@@ -47,6 +47,7 @@ class AppPreferences(context: Context) {
         val style; get() = prefs.getString("gesture_style", "touchscreen")!!
         val tap1 = "left-click" //Preference UI was removed
         val tap2; get() = prefs.getString("gesture_tap2", "open-keyboard")!!
+        val tap3; get() = prefs.getString("gesture_tap3", "middle-click")!!
         val doubleTap; get() = prefs.getString("gesture_double_tap", "double-click")!!
         val longPress; get() = prefs.getString("gesture_long_press", "right-click")!!
         val swipe1; get() = prefs.getString("gesture_swipe1", "pan")!!

--- a/app/src/main/java/com/gaurav/avnc/util/AppPreferences.kt
+++ b/app/src/main/java/com/gaurav/avnc/util/AppPreferences.kt
@@ -47,7 +47,7 @@ class AppPreferences(context: Context) {
         val style; get() = prefs.getString("gesture_style", "touchscreen")!!
         val tap1 = "left-click" //Preference UI was removed
         val tap2; get() = prefs.getString("gesture_tap2", "open-keyboard")!!
-        val tap3; get() = prefs.getString("gesture_tap3", "middle-click")!!
+        val tap3; get() = prefs.getString("gesture_tap3", "none")!!
         val doubleTap; get() = prefs.getString("gesture_double_tap", "double-click")!!
         val longPress; get() = prefs.getString("gesture_long_press", "right-click")!!
         val swipe1; get() = prefs.getString("gesture_swipe1", "pan")!!

--- a/app/src/main/java/com/gaurav/avnc/util/AppPreferences.kt
+++ b/app/src/main/java/com/gaurav/avnc/util/AppPreferences.kt
@@ -52,6 +52,7 @@ class AppPreferences(context: Context) {
         val longPress; get() = prefs.getString("gesture_long_press", "right-click")!!
         val swipe1; get() = prefs.getString("gesture_swipe1", "pan")!!
         val swipe2; get() = prefs.getString("gesture_swipe2", "pan")!!
+        val swipe3; get() = prefs.getString("gesture_swipe3", "pan")!!
         val doubleTapSwipe; get() = prefs.getString("gesture_double_tap_swipe", "remote-drag")!!
         val longPressSwipe; get() = prefs.getString("gesture_long_press_swipe", "none")!!
         val longPressSwipeEnabled; get() = (longPressSwipe != "none" && longPress != "left-press")

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -122,6 +122,17 @@
         <item>remote-scroll</item>
     </string-array>
 
+    <string-array name="swipe3_action_entries">
+        <item>@string/pref_gesture_action_none</item>
+        <item>@string/pref_gesture_action_pan</item>
+        <item>@string/pref_gesture_action_remote_scroll</item>
+    </string-array>
+    <string-array name="swipe3_action_values">
+        <item>none</item>
+        <item>pan</item>
+        <item>remote-scroll</item>
+    </string-array>
+
     <string-array name="double_tap_swipe_action_entries">
         <item>@string/pref_gesture_action_none</item>
         <item>@string/pref_gesture_action_remote_drag</item>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -62,7 +62,7 @@
     <string-array name="tap3_action_entries">
         <item>@string/pref_gesture_action_none</item>
         <item>@string/pref_gesture_action_right_click</item>
-        <item>@string/pref_gesture_action_open_keyboard</item>
+        <item>@string/pref_gesture_action_middle_click</item>
     </string-array>
     <string-array name="tap3_action_values">
         <item>none</item>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -59,6 +59,17 @@
         <item>open-keyboard</item>
     </string-array>
 
+    <string-array name="tap3_action_entries">
+        <item>@string/pref_gesture_action_none</item>
+        <item>@string/pref_gesture_action_right_click</item>
+        <item>@string/pref_gesture_action_open_keyboard</item>
+    </string-array>
+    <string-array name="tap3_action_values">
+        <item>none</item>
+        <item>right-click</item>
+        <item>middle-click</item>
+    </string-array>
+
     <string-array name="double_tap_action_entries">
         <item>@string/pref_gesture_action_none</item>
         <item>@string/pref_gesture_action_double_click</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -188,6 +188,7 @@
     <string name="pref_long_press">Long press</string>
     <string name="pref_swipe1">One-finger swipe</string>
     <string name="pref_swipe2">Two-finger swipe</string>
+    <string name="pref_swipe3">Three-finger swipe</string>
     <string name="pref_double_tap_swipe">Double tap and swipe</string>
     <string name="pref_long_press_swipe">Long press and swipe</string>
     <string name="pref_swipe_sensitivity">Swipe sensitivity</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -183,6 +183,7 @@
     <string name="pref_gesture_style_touchpad_summary">Do actions at pointer</string>
     <string name="pref_single_tap">Single tap</string>
     <string name="pref_two_finger_tap">Two-finger tap</string>
+    <string name="pref_three_finger_tap">Three-finger tap</string>
     <string name="pref_double_tap">Double tap</string>
     <string name="pref_long_press">Long press</string>
     <string name="pref_swipe1">One-finger swipe</string>

--- a/app/src/main/res/xml/pref_input.xml
+++ b/app/src/main/res/xml/pref_input.xml
@@ -72,6 +72,14 @@
             app:title="@string/pref_swipe2"
             app:useSimpleSummaryProvider="true" />
 
+        <ListPreference
+            app:defaultValue="pan"
+            app:entries="@array/swipe3_action_entries"
+            app:entryValues="@array/swipe3_action_values"
+            app:key="gesture_swipe3"
+            app:title="@string/pref_swipe3"
+            app:useSimpleSummaryProvider="true" />
+
         <com.gaurav.avnc.ui.prefs.ListPreferenceEx
             app:defaultValue="remote-drag"
             app:entries="@array/double_tap_swipe_action_entries"

--- a/app/src/main/res/xml/pref_input.xml
+++ b/app/src/main/res/xml/pref_input.xml
@@ -72,7 +72,7 @@
             app:title="@string/pref_swipe2"
             app:useSimpleSummaryProvider="true" />
 
-        <com.gaurav.avnc.ui.prefs.ListPreferenceEx
+        <ListPreference
             app:defaultValue="pan"
             app:entries="@array/swipe3_action_entries"
             app:entryValues="@array/swipe3_action_values"

--- a/app/src/main/res/xml/pref_input.xml
+++ b/app/src/main/res/xml/pref_input.xml
@@ -48,6 +48,14 @@
             app:title="@string/pref_two_finger_tap"
             app:useSimpleSummaryProvider="true" />
 
+        <ListPreference
+            app:defaultValue="middle-click"
+            app:entries="@array/tap3_action_entries"
+            app:entryValues="@array/tap3_action_values"
+            app:key="gesture_tap3"
+            app:title="@string/pref_three_finger_tap"
+            app:useSimpleSummaryProvider="true" />
+
         <com.gaurav.avnc.ui.prefs.ListPreferenceEx
             app:defaultValue="pan"
             app:entries="@array/swipe1_action_entries"

--- a/app/src/main/res/xml/pref_input.xml
+++ b/app/src/main/res/xml/pref_input.xml
@@ -72,7 +72,7 @@
             app:title="@string/pref_swipe2"
             app:useSimpleSummaryProvider="true" />
 
-        <ListPreference
+        <com.gaurav.avnc.ui.prefs.ListPreferenceEx
             app:defaultValue="pan"
             app:entries="@array/swipe3_action_entries"
             app:entryValues="@array/swipe3_action_values"

--- a/app/src/main/res/xml/pref_input.xml
+++ b/app/src/main/res/xml/pref_input.xml
@@ -49,7 +49,7 @@
             app:useSimpleSummaryProvider="true" />
 
         <ListPreference
-            app:defaultValue="middle-click"
+            app:defaultValue="none"
             app:entries="@array/tap3_action_entries"
             app:entryValues="@array/tap3_action_values"
             app:key="gesture_tap3"


### PR DESCRIPTION
This resolves #286 by adding support for swipe and tap actions for three fingers.

It is mostly useful for touchpad mode: tap is useful as a middle-click option, and swipe allows to have "remote-scroll" and "pan" actions available simultaneously.

I've decided to make three-finger tap disabled in touchscreen mode because it is hard to aim at a specific position with three fingers.

I've tested this on Xiamoi Mi Note 10 Lite with wayvnc as a server.