### PR TITLE
Option to turn off video completely

### DIFF
--- a/app/roomSchema/com.gaurav.avnc.model.db.MainDb/6.json
+++ b/app/roomSchema/com.gaurav.avnc.model.db.MainDb/6.json
@@ -2,11 +2,11 @@
   "formatVersion": 1,
   "database": {
     "version": 6,
-    "identityHash": "7d25813fc2619854164fe3d395f2aa28",
+    "identityHash": "3dece850f91de0f07a5614d6c32e3557",
     "entities": [
       {
         "tableName": "profiles",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`ID` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `host` TEXT NOT NULL, `port` INTEGER NOT NULL, `username` TEXT NOT NULL, `password` TEXT NOT NULL, `securityType` INTEGER NOT NULL, `channelType` INTEGER NOT NULL, `colorLevel` INTEGER NOT NULL, `imageQuality` INTEGER NOT NULL, `useRawEncoding` INTEGER NOT NULL DEFAULT 0, `zoom1` REAL NOT NULL DEFAULT 1.0, `zoom2` REAL NOT NULL DEFAULT 1.0, `viewOnly` INTEGER NOT NULL, `useLocalCursor` INTEGER NOT NULL, `serverTypeHint` TEXT NOT NULL DEFAULT '', `flags` INTEGER NOT NULL, `gestureStyle` TEXT NOT NULL DEFAULT 'auto', `screenOrientation` TEXT NOT NULL DEFAULT 'auto', `useCount` INTEGER NOT NULL, `useRepeater` INTEGER NOT NULL, `idOnRepeater` INTEGER NOT NULL, `resizeRemoteDesktop` INTEGER NOT NULL DEFAULT 0, `enableWol` INTEGER NOT NULL DEFAULT 0, `wolMAC` TEXT NOT NULL DEFAULT '', `sshHost` TEXT NOT NULL, `sshPort` INTEGER NOT NULL, `sshUsername` TEXT NOT NULL, `sshAuthType` INTEGER NOT NULL, `sshPassword` TEXT NOT NULL, `sshPrivateKey` TEXT NOT NULL, `sshPrivateKeyPassword` TEXT NOT NULL)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`ID` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `host` TEXT NOT NULL, `port` INTEGER NOT NULL, `username` TEXT NOT NULL, `password` TEXT NOT NULL, `securityType` INTEGER NOT NULL, `channelType` INTEGER NOT NULL, `colorLevel` INTEGER NOT NULL, `imageQuality` INTEGER NOT NULL, `useRawEncoding` INTEGER NOT NULL DEFAULT 0, `disableImageUpdates` INTEGER NOT NULL DEFAULT 0, `zoom1` REAL NOT NULL DEFAULT 1.0, `zoom2` REAL NOT NULL DEFAULT 1.0, `viewOnly` INTEGER NOT NULL, `useLocalCursor` INTEGER NOT NULL, `serverTypeHint` TEXT NOT NULL DEFAULT '', `flags` INTEGER NOT NULL, `gestureStyle` TEXT NOT NULL DEFAULT 'auto', `screenOrientation` TEXT NOT NULL DEFAULT 'auto', `useCount` INTEGER NOT NULL, `useRepeater` INTEGER NOT NULL, `idOnRepeater` INTEGER NOT NULL, `resizeRemoteDesktop` INTEGER NOT NULL DEFAULT 0, `enableWol` INTEGER NOT NULL DEFAULT 0, `wolMAC` TEXT NOT NULL DEFAULT '', `sshHost` TEXT NOT NULL, `sshPort` INTEGER NOT NULL, `sshUsername` TEXT NOT NULL, `sshAuthType` INTEGER NOT NULL, `sshPassword` TEXT NOT NULL, `sshPrivateKey` TEXT NOT NULL, `sshPrivateKeyPassword` TEXT NOT NULL)",
         "fields": [
           {
             "fieldPath": "ID",
@@ -71,6 +71,13 @@
           {
             "fieldPath": "useRawEncoding",
             "columnName": "useRawEncoding",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "disableImageUpdates",
+            "columnName": "disableImageUpdates",
             "affinity": "INTEGER",
             "notNull": true,
             "defaultValue": "0"
@@ -223,7 +230,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7d25813fc2619854164fe3d395f2aa28')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '3dece850f91de0f07a5614d6c32e3557')"
     ]
   }
 }

--- a/app/src/main/java/com/gaurav/avnc/model/ServerProfile.kt
+++ b/app/src/main/java/com/gaurav/avnc/model/ServerProfile.kt
@@ -89,6 +89,13 @@ data class ServerProfile(
         var useRawEncoding: Boolean = false,
 
         /**
+         * Stop rendering frame buffer.
+         * This can save battery while still allowing control of the remote device.
+         */
+        @ColumnInfo(defaultValue = "0")
+        var disableImageUpdates: Boolean = false,
+
+        /**
          * Initial zoom for the viewer.
          * This will be used in portrait orientation, or when per-orientation zooming is disabled.
          */

--- a/app/src/main/java/com/gaurav/avnc/ui/home/ProfileEditor.kt
+++ b/app/src/main/java/com/gaurav/avnc/ui/home/ProfileEditor.kt
@@ -187,6 +187,7 @@ class AdvancedProfileEditor : Fragment() {
         //setupHelpButton(binding.keyCompatModeHelpBtn, R.string.title_key_compat_mode, R.string.msg_key_compat_mode_help)
         setupHelpButton(binding.buttonUpDelayHelpBtn, R.string.title_button_up_delay, R.string.msg_button_up_delay_help)
         setupHelpButton(binding.wolHelpBtn, R.string.title_enable_wol, R.string.msg_wake_on_lan_help)
+        setupHelpButton(binding.disableImageUpdatesHelpBtn, R.string.title_disable_image_updates, R.string.msg_disable_image_updates_help)
         setupNightModeNavBarColor()
         setupToolbarMenu()
 

--- a/app/src/main/java/com/gaurav/avnc/ui/vnc/gl/Renderer.kt
+++ b/app/src/main/java/com/gaurav/avnc/ui/vnc/gl/Renderer.kt
@@ -73,8 +73,7 @@ class Renderer(val viewModel: VncViewModel) : GLSurfaceView.Renderer {
      */
     override fun onDrawFrame(gl: GL10?) {
         glClear(GL_COLOR_BUFFER_BIT)
-
-        if (!viewModel.client.connected)
+        if (!viewModel.client.connected || viewModel.profile.disableImageUpdates)
             return
 
         val state = viewModel.frameState.getSnapshot()

--- a/app/src/main/java/com/gaurav/avnc/viewmodel/EditorViewModel.kt
+++ b/app/src/main/java/com/gaurav/avnc/viewmodel/EditorViewModel.kt
@@ -34,6 +34,7 @@ class EditorViewModel(app: Application, state: SavedStateHandle, initialProfile:
     val useRepeater = state.getLiveData("useRepeater", profile.useRepeater)
     val idOnRepeater = state.getLiveData("idOnRepeater", if (profile.useRepeater) profile.idOnRepeater.toString() else "")
     val useRawEncoding = state.getLiveData("useRawEncoding", profile.useRawEncoding)
+    val disableImageUpdates = state.getLiveData("disableImageUpdates", profile.disableImageUpdates)
     val enableWol = state.getLiveData("enableWol", profile.enableWol)
     val useSshTunnel = state.getLiveData("useSshTunnel", profile.channelType == ServerProfile.CHANNEL_SSH_TUNNEL)
     val sshUsePassword = state.getLiveData("sshUsePassword", profile.sshAuthType == ServerProfile.SSH_AUTH_PASSWORD)
@@ -45,6 +46,7 @@ class EditorViewModel(app: Application, state: SavedStateHandle, initialProfile:
         profile.useRepeater = useRepeater.value ?: false
         profile.idOnRepeater = idOnRepeater.value?.toIntOrNull() ?: 0
         profile.useRawEncoding = useRawEncoding.value ?: false
+        profile.disableImageUpdates = disableImageUpdates.value ?: false
         profile.enableWol = enableWol.value ?: false
         profile.channelType = if (useSshTunnel.value == true) ServerProfile.CHANNEL_SSH_TUNNEL else ServerProfile.CHANNEL_TCP
         profile.sshAuthType = if (sshUsePassword.value == true) ServerProfile.SSH_AUTH_PASSWORD else ServerProfile.SSH_AUTH_KEY

--- a/app/src/main/res/layout/fragment_profile_editor_advanced.xml
+++ b/app/src/main/res/layout/fragment_profile_editor_advanced.xml
@@ -278,6 +278,26 @@
                     app:layout_constraintStart_toEndOf="@id/image_quality"
                     app:layout_constraintTop_toTopOf="@id/image_quality" />
 
+                <CheckBox
+                    android:id="@+id/disable_image_updates"
+                    style="@style/FormField.CheckBox"
+                    android:layout_width="wrap_content"
+                    android:layout_height="@dimen/action_btn_size"
+                    android:checked="@={viewModel.disableImageUpdates}"
+                    android:text="@string/title_disable_image_updates"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/image_quality" />
+
+                <ImageButton
+                    android:id="@+id/disable_image_updates_help_btn"
+                    style="@style/ImageButton"
+                    android:contentDescription="@string/desc_help_btn"
+                    android:src="@drawable/ic_help"
+                    app:layout_constraintBottom_toBottomOf="@id/disable_image_updates"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/disable_image_updates"
+                    app:tint="?colorControlNormal" />
+
 
                 <!--Gesture style-->
                 <TextView
@@ -297,7 +317,7 @@
                     android:minHeight="@dimen/action_btn_size"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="@id/image_quality"
-                    app:layout_constraintTop_toBottomOf="@id/image_quality"
+                    app:layout_constraintTop_toBottomOf="@id/disable_image_updates"
                     app:value="@={viewModel.profile.gestureStyle}"
                     app:valueDescriptions="@{ @stringArray/profile_editor_gesture_style_descriptions }"
                     app:valueLabels="@{ @stringArray/profile_editor_gesture_style_labels }"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,6 +40,7 @@
     <string name="title_image_quality">Image quality</string>
     <string name="title_orientation">Orientation</string>
     <string name="title_image_quality_raw">Raw</string>
+    <string name="title_disable_image_updates">Disable image updates (Experimental)</string>
     <string name="title_vnc_security">Security</string>
     <string name="title_use_ssh_tunnel">Use SSH tunnel</string>
     <string name="title_always_show_advanced_editor">Always show advanced options</string>
@@ -106,6 +107,7 @@
     <string name="msg_key_compat_mode_help">Some servers have limited Unicode support. Legacy key events can help input non-English text.</string>
     <string name="msg_button_up_delay_help">Delaying click events can help in some rare cases if an app is not responding to clicks.</string>
     <string name="msg_wake_on_lan_help">Wake-on-LAN can be used to remotely power-on a computer.\n\nFirst, configure WoL on remote computer, then enable it in AVNC.\nOnce enabled, WoL magic packet will be automatically sent before connecting to this server.</string>
+    <string name="msg_disable_image_updates_help">Stops rendering the recieved remote image.\nWith this setting on the data is still transmitted and is controlled with "Image quality" setting.\nThis can be useful to control remote device while saving battery. It is recommended to turn off "pan local frame" in the input settings.</string>
     <string name="msg_gesture_style_help"><b>Touchscreen</b>\nDo actions at touch-point \n\n<b>Touchpad</b>\nDo actions at pointer</string>
     <string name="msg_drag_gesture_help">Assigning an action to this gesture will change Long press detection:\n\n<b>Press-hold-release</b> → Long press\n<b>Press-hold-swipe</b> → Long press and swipe</string>
     <string name="msg_shortcut_server_deleted">This server has been deleted</string>


### PR DESCRIPTION
In #154 you wrote:

> Yes, as an experimental option. What I am actually planning is to pause framebuffer updates whenever AVNC is in background. It should reduce battery/bandwidth usage for everybody <...> Turning off video completely will be an extension of this.

However, there's no option to turn off video completely yet. I've made an attempt to achieve this by adding an option "Disable image updates" to the server profile, and with this on the received image stops rendering.

All the control is still available to the user (e.g. using keyboard/virtual keyboard, touchpad or touchscreen).

I understand that the "full remote control" is not the intended feature for this app, but the change seems simple enough to support it, since it's a common request.
