### PR TITLE
Remove some non-determinism

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,6 +1,8 @@
 
 cmake_minimum_required(VERSION 3.10)
 
+add_link_options("LINKER:--build-id=none")
+
 project(NativeVNC C CXX ASM)
 
 set(AVNC_EXTERN_DIR ${PROJECT_SOURCE_DIR}/../extern)


### PR DESCRIPTION
Your app is not built reproducible in F-Droid, but we continuously test older versions on https://verification.f-droid.org/ and would like more and more apps to become repro

Looking at the latest app report: https://verification.f-droid.org/packages/com.gaurav.avnc

We can remove the build id by adding this to the cmake file

and the timestamp diff block will be fixed on our side once https://gitlab.com/fdroid/fdroidserver/-/merge_requests/1653 gets merged