### PR TITLE
Import/export with a QR code

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -125,6 +125,7 @@ dependencies {
     implementation("com.google.android.material:material:1.7.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
     implementation("org.connectbot:sshlib:2.2.36")
+    implementation("com.journeyapps:zxing-android-embedded:4.3.0")
 
     debugImplementation("com.squareup.leakcanary:leakcanary-android:2.14")
 

--- a/app/src/androidTest/java/com/gaurav/avnc/util/QrCodeTest.kt
+++ b/app/src/androidTest/java/com/gaurav/avnc/util/QrCodeTest.kt
@@ -79,6 +79,22 @@ class QrCodeTest {
         assertEquals("", json.json)
     }
 
+    @Test
+    fun encodeJson() {
+        val encoded = QrCode.encode("{\"profiles\":[]}")
+        assertEquals("AVNC:DATA;{\"profiles\":[]}", encoded)
+    }
+
+    @Test
+    fun encodeThenDecodeJson() {
+        val original = "{\"a\":\"x;y:z\"}"
+        val decoded = QrCode.decode(QrCode.encode(original))
+
+        val json = decoded as? QrCode.Content.Json
+            ?: throw AssertionError("Expected Json content, got $decoded")
+        assertEquals(original, json.json)
+    }
+
     private fun assertThrows(block: () -> Any?) {
         try {
             block()

--- a/app/src/androidTest/java/com/gaurav/avnc/util/QrCodeTest.kt
+++ b/app/src/androidTest/java/com/gaurav/avnc/util/QrCodeTest.kt
@@ -1,0 +1,91 @@
+package com.gaurav.avnc.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class QrCodeTest {
+
+    @Test
+    fun decodeJson() {
+        val actual = QrCode.decode("AVNC:DATA;{\"profiles\":[]}")
+
+        val json = actual as? QrCode.Content.Json
+            ?: throw AssertionError("Expected Json content, got $actual")
+        assertEquals("{\"profiles\":[]}", json.json)
+    }
+
+    @Test
+    fun decodeJsonWithOption() {
+        val actual = QrCode.decode("AVNC:DATA:opt1:opt2;{json}")
+
+        val json = actual as? QrCode.Content.Json
+            ?: throw AssertionError("Expected Json content, got $actual")
+        assertEquals("{json}", json.json)
+    }
+
+    @Test
+    fun decodeJsonPreservesSeparatorsInPayload() {
+        // ':' and ';' inside the JSON payload should be preserved
+        val actual = QrCode.decode("AVNC:DATA;{\"a\":\"x;y:z\"}")
+
+        val json = actual as? QrCode.Content.Json
+            ?: throw AssertionError("Expected Json content, got $actual")
+        assertEquals("{\"a\":\"x;y:z\"}", json.json)
+    }
+
+    @Test
+    fun decodeUri() {
+        val actual = QrCode.decode("AVNC:URI;vnc://10.0.0.1:5901/")
+
+        val uri = actual as? QrCode.Content.Uri
+            ?: throw AssertionError("Expected Uri content, got $actual")
+        assertEquals("vnc", uri.uri.scheme)
+        assertEquals("10.0.0.1", uri.uri.host)
+    }
+
+    @Test
+    fun decodeUriWithOption() {
+        val actual = QrCode.decode("AVNC:URI:opt;https://example.com/config")
+
+        val uri = actual as? QrCode.Content.Uri
+            ?: throw AssertionError("Expected Uri content, got $actual")
+        assertEquals("https", uri.uri.scheme)
+        assertEquals("example.com", uri.uri.host)
+    }
+
+    @Test
+    fun rejectAppendedTextInHeader() {
+        // "AVNC:DATABLAH" should not be treated as AVNC:DATA
+        assertThrows { QrCode.decode("AVNC:DATABLAH;{}") }
+    }
+
+    @Test
+    fun rejectUnknownType() {
+        assertThrows { QrCode.decode("AVNC:FOO;{}") }
+    }
+
+    @Test
+    fun rejectMissingHeader() {
+        assertThrows { QrCode.decode("{}") }
+    }
+
+    @Test
+    fun decodeBlankJsonPayload() {
+        // Structural decoding succeeds; JSON validity is checked by the importer later.
+        val actual = QrCode.decode("AVNC:DATA;")
+
+        val json = actual as? QrCode.Content.Json
+            ?: throw AssertionError("Expected Json content, got $actual")
+        assertEquals("", json.json)
+    }
+
+    private fun assertThrows(block: () -> Any?) {
+        try {
+            block()
+        } catch (_: QrCode.InvalidQrCodeException) {
+            return
+        }
+        throw AssertionError("Expected QrCode.InvalidQrCodeException")
+    }
+
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,10 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
 
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
+
     <application
         android:name=".App"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:hardwareAccelerated="true"
         android:theme="@style/App.Theme">
 
         <activity-alias

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
         android:name=".App"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/App.Theme">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,7 +22,6 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:hardwareAccelerated="true"
         android:theme="@style/App.Theme">
 
         <activity-alias

--- a/app/src/main/java/com/gaurav/avnc/ui/prefs/ImportExportFragment.kt
+++ b/app/src/main/java/com/gaurav/avnc/ui/prefs/ImportExportFragment.kt
@@ -10,10 +10,7 @@ package com.gaurav.avnc.ui.prefs
 
 import android.content.ActivityNotFoundException
 import android.content.Intent
-import android.graphics.Bitmap
-import android.graphics.Color
 import android.net.Uri
-import android.widget.ImageView
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
@@ -32,17 +29,11 @@ import com.gaurav.avnc.util.MsgDialog
 import com.gaurav.avnc.util.OpenableDocument
 import com.gaurav.avnc.util.QrCode
 import com.gaurav.avnc.viewmodel.PrefsViewModel
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
-import com.google.zxing.BarcodeFormat
-import com.google.zxing.WriterException
-import com.google.zxing.qrcode.QRCodeWriter
 import com.journeyapps.barcodescanner.ScanContract
 import com.journeyapps.barcodescanner.ScanOptions
 import java.text.DateFormat
 import java.util.Date
-import androidx.core.graphics.createBitmap
-import androidx.core.graphics.set
 
 @Keep
 class ImportExportFragment : Fragment() {
@@ -188,26 +179,8 @@ class ImportExportFragment : Fragment() {
      * Shows the exported [json] as a QR code in a dialog.
      */
     private fun showQrDialog(json: String) {
-        try {
-            val matrix = QRCodeWriter().encode(QrCode.encode(json), BarcodeFormat.QR_CODE, 512, 512)
-            val bitmap = createBitmap(matrix.width, matrix.height, Bitmap.Config.RGB_565)
-            for (x in 0 until matrix.width)
-                for (y in 0 until matrix.height)
-                    bitmap[x, y] = if (matrix[x, y]) Color.BLACK else Color.WHITE
-
-            val image = ImageView(requireContext()).apply {
-                setImageBitmap(bitmap)
-                adjustViewBounds = true
-            }
-
-            MaterialAlertDialogBuilder(requireContext())
-                    .setTitle(R.string.title_export_qr)
-                    .setView(image)
-                    .setPositiveButton(android.R.string.ok, null)
-                    .show()
-        } catch (e: WriterException) {
-            MsgDialog.show(childFragmentManager, "Error", getString(R.string.err_qr_export_failed))
-            Log.e(javaClass.simpleName, "Failed to generate QR code.", e)
-        }
+        val title = getString(R.string.title_export_qr)
+        val data = QrCode.encode(json)
+        QrDialog.show(childFragmentManager, title, data)
     }
 }

--- a/app/src/main/java/com/gaurav/avnc/ui/prefs/ImportExportFragment.kt
+++ b/app/src/main/java/com/gaurav/avnc/ui/prefs/ImportExportFragment.kt
@@ -10,7 +10,10 @@ package com.gaurav.avnc.ui.prefs
 
 import android.content.ActivityNotFoundException
 import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.Color
 import android.net.Uri
+import android.widget.ImageView
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
@@ -21,6 +24,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.Keep
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.MutableLiveData
 import com.gaurav.avnc.R
 import com.gaurav.avnc.databinding.FragmentImportExportBinding
 import com.gaurav.avnc.util.DeviceAuthPrompt
@@ -30,15 +34,20 @@ import com.gaurav.avnc.util.QrCode
 import com.gaurav.avnc.viewmodel.PrefsViewModel
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.WriterException
+import com.google.zxing.qrcode.QRCodeWriter
 import com.journeyapps.barcodescanner.ScanContract
 import com.journeyapps.barcodescanner.ScanOptions
 import java.text.DateFormat
 import java.util.Date
+import androidx.core.graphics.createBitmap
+import androidx.core.graphics.set
 
 @Keep
 class ImportExportFragment : Fragment() {
 
-    private enum class Tag { Import, ImportQr, Export }
+    private enum class Tag { Import, ImportQr, Export, ExportQr }
 
     private val importFilePicker = registerForActivityResult(OpenableDocument()) { import(it) }
     private val exportFilePicker = registerForActivityResult(ActivityResultContracts.CreateDocument("*/*")) { export(it) }
@@ -61,7 +70,6 @@ class ImportExportFragment : Fragment() {
     private val viewModel by activityViewModels<PrefsViewModel>()
     private val authPrompt by lazy { DeviceAuthPrompt(requireActivity()) }
 
-
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         binding = FragmentImportExportBinding.inflate(inflater, container, false)
         binding.lifecycleOwner = viewLifecycleOwner
@@ -70,6 +78,7 @@ class ImportExportFragment : Fragment() {
         binding.importBtn.setOnClickListener { checkAuthAndStart(Tag.Import) }
         binding.importQrBtn.setOnClickListener { checkAuthAndStart(Tag.ImportQr) }
         binding.exportBtn.setOnClickListener { checkAuthAndStart(Tag.Export) }
+        binding.exportQrBtn.setOnClickListener { checkAuthAndStart(Tag.ExportQr) }
 
         viewModel.importExportFinishedEvent.observe(viewLifecycleOwner) { handleImportExportResult(it) }
 
@@ -115,6 +124,11 @@ class ImportExportFragment : Fragment() {
             Tag.Import -> launchFilePicker(importFilePicker, arrayOf("*/*"))
             Tag.ImportQr -> launchScan()
             Tag.Export -> launchFilePicker(exportFilePicker, generateFilename())
+            Tag.ExportQr -> {
+                val json = MutableLiveData<String>()
+                json.observe(viewLifecycleOwner) { showQrDialog(it) }
+                viewModel.export(json)
+            }
         }
     }
 
@@ -162,10 +176,38 @@ class ImportExportFragment : Fragment() {
 
     private fun handleImportExportResult(result: Result<String>) {
         result.onSuccess {
-            showMsg(it)
+            if (it.isNotEmpty())
+                showMsg(it)
         }.onFailure {
             MsgDialog.show(childFragmentManager, "Error", it.message ?: "An error occurred")
             Log.e(javaClass.simpleName, "Import/Export error", it)
+        }
+    }
+
+    /**
+     * Shows the exported [json] as a QR code in a dialog.
+     */
+    private fun showQrDialog(json: String) {
+        try {
+            val matrix = QRCodeWriter().encode(QrCode.encode(json), BarcodeFormat.QR_CODE, 512, 512)
+            val bitmap = createBitmap(matrix.width, matrix.height, Bitmap.Config.RGB_565)
+            for (x in 0 until matrix.width)
+                for (y in 0 until matrix.height)
+                    bitmap[x, y] = if (matrix[x, y]) Color.BLACK else Color.WHITE
+
+            val image = ImageView(requireContext()).apply {
+                setImageBitmap(bitmap)
+                adjustViewBounds = true
+            }
+
+            MaterialAlertDialogBuilder(requireContext())
+                    .setTitle(R.string.title_export_qr)
+                    .setView(image)
+                    .setPositiveButton(android.R.string.ok, null)
+                    .show()
+        } catch (e: WriterException) {
+            MsgDialog.show(childFragmentManager, "Error", getString(R.string.err_qr_export_failed))
+            Log.e(javaClass.simpleName, "Failed to generate QR code.", e)
         }
     }
 }

--- a/app/src/main/java/com/gaurav/avnc/ui/prefs/ImportExportFragment.kt
+++ b/app/src/main/java/com/gaurav/avnc/ui/prefs/ImportExportFragment.kt
@@ -19,11 +19,13 @@ import android.view.ViewGroup
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.Keep
+import androidx.core.os.BundleCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.MutableLiveData
 import com.gaurav.avnc.R
 import com.gaurav.avnc.databinding.FragmentImportExportBinding
+import com.gaurav.avnc.util.ConfirmDialog
 import com.gaurav.avnc.util.DeviceAuthPrompt
 import com.gaurav.avnc.util.MsgDialog
 import com.gaurav.avnc.util.OpenableDocument
@@ -39,6 +41,11 @@ import java.util.Date
 class ImportExportFragment : Fragment() {
 
     private enum class Tag { Import, ImportQr, Export, ExportQr }
+
+    companion object {
+        private const val REQUEST_IMPORT_URI = "request_import_uri"
+        private const val KEY_IMPORT_URI = "import_uri"
+    }
 
     private val importFilePicker = registerForActivityResult(OpenableDocument()) { import(it) }
     private val exportFilePicker = registerForActivityResult(ActivityResultContracts.CreateDocument("*/*")) { export(it) }
@@ -72,6 +79,12 @@ class ImportExportFragment : Fragment() {
         binding.exportQrBtn.setOnClickListener { checkAuthAndStart(Tag.ExportQr) }
 
         viewModel.importExportFinishedEvent.observe(viewLifecycleOwner) { handleImportExportResult(it) }
+
+        childFragmentManager.setFragmentResultListener(REQUEST_IMPORT_URI, viewLifecycleOwner) { _, bundle ->
+            val uri = BundleCompat.getParcelable(bundle, KEY_IMPORT_URI, Uri::class.java)
+                    ?: return@setFragmentResultListener
+            viewModel.import(uri)
+        }
 
         authPrompt.init(
                 onSuccess = { checkNotNull(it as? Tag); start(it) },
@@ -141,10 +154,16 @@ class ImportExportFragment : Fragment() {
 
     /**
      * Handles an `AVNC:URI` decoded from a QR code.
+     * Displays the URI and asks the user for confirmation before dereferencing it.
      */
     private fun handleImportedUri(uri: Uri) {
         when (uri.scheme) {
-            "file", "http", "https" -> viewModel.import(uri)
+            "file", "http", "https" -> {
+                val title = getString(R.string.title_import)
+                val msg = "${getString(R.string.msg_confirm_import_uri)}\n\n$uri"
+                val result = Bundle().apply { putParcelable(KEY_IMPORT_URI, uri) }
+                ConfirmDialog.show(childFragmentManager, REQUEST_IMPORT_URI, title, msg, result)
+            }
             else -> showMsg(getString(R.string.err_unsupported_qr_uri))
         }
     }

--- a/app/src/main/java/com/gaurav/avnc/ui/prefs/ImportExportFragment.kt
+++ b/app/src/main/java/com/gaurav/avnc/ui/prefs/ImportExportFragment.kt
@@ -149,7 +149,6 @@ class ImportExportFragment : Fragment() {
      */
     private fun handleImportedUri(uri: Uri) {
         when (uri.scheme) {
-            "vnc" -> startActivity(Intent(Intent.ACTION_VIEW, uri))
             "file", "http", "https" -> viewModel.import(uri)
             else -> showMsg(getString(R.string.err_unsupported_qr_uri))
         }

--- a/app/src/main/java/com/gaurav/avnc/ui/prefs/ImportExportFragment.kt
+++ b/app/src/main/java/com/gaurav/avnc/ui/prefs/ImportExportFragment.kt
@@ -136,12 +136,7 @@ class ImportExportFragment : Fragment() {
         val options = ScanOptions()
                 .setDesiredBarcodeFormats(ScanOptions.QR_CODE)
                 .setPrompt(getString(R.string.title_import_qr))
-        try {
-            scanCode.launch(options)
-        } catch (e: ActivityNotFoundException) {
-            showMsg(getString(R.string.err_no_scan_app))
-            Log.e(javaClass.simpleName, "No app found to scan QR code.", e)
-        }
+        scanCode.launch(options)
     }
 
     /**

--- a/app/src/main/java/com/gaurav/avnc/ui/prefs/ImportExportFragment.kt
+++ b/app/src/main/java/com/gaurav/avnc/ui/prefs/ImportExportFragment.kt
@@ -9,6 +9,7 @@
 package com.gaurav.avnc.ui.prefs
 
 import android.content.ActivityNotFoundException
+import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.util.Log
@@ -25,18 +26,36 @@ import com.gaurav.avnc.databinding.FragmentImportExportBinding
 import com.gaurav.avnc.util.DeviceAuthPrompt
 import com.gaurav.avnc.util.MsgDialog
 import com.gaurav.avnc.util.OpenableDocument
+import com.gaurav.avnc.util.QrCode
 import com.gaurav.avnc.viewmodel.PrefsViewModel
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
+import com.journeyapps.barcodescanner.ScanContract
+import com.journeyapps.barcodescanner.ScanOptions
 import java.text.DateFormat
 import java.util.Date
 
 @Keep
 class ImportExportFragment : Fragment() {
 
-    private enum class Tag { Import, Export }
+    private enum class Tag { Import, ImportQr, Export }
 
     private val importFilePicker = registerForActivityResult(OpenableDocument()) { import(it) }
     private val exportFilePicker = registerForActivityResult(ActivityResultContracts.CreateDocument("*/*")) { export(it) }
+    private val scanCode = registerForActivityResult(ScanContract()) { scanResult ->
+        val content = scanResult?.contents ?: return@registerForActivityResult
+        val decoded = try {
+            QrCode.decode(content)
+        } catch (_: QrCode.InvalidQrCodeException) {
+            showMsg(getString(R.string.err_invalid_qr_code))
+            return@registerForActivityResult
+        }
+
+        when (decoded) {
+            is QrCode.Content.Json -> viewModel.import(decoded.json)
+            is QrCode.Content.Uri -> handleImportedUri(decoded.uri)
+        }
+    }
 
     private lateinit var binding: FragmentImportExportBinding
     private val viewModel by activityViewModels<PrefsViewModel>()
@@ -49,6 +68,7 @@ class ImportExportFragment : Fragment() {
         binding.viewModel = viewModel
 
         binding.importBtn.setOnClickListener { checkAuthAndStart(Tag.Import) }
+        binding.importQrBtn.setOnClickListener { checkAuthAndStart(Tag.ImportQr) }
         binding.exportBtn.setOnClickListener { checkAuthAndStart(Tag.Export) }
 
         viewModel.importExportFinishedEvent.observe(viewLifecycleOwner) { handleImportExportResult(it) }
@@ -93,6 +113,7 @@ class ImportExportFragment : Fragment() {
     private fun start(tag: Tag) {
         when (tag) {
             Tag.Import -> launchFilePicker(importFilePicker, arrayOf("*/*"))
+            Tag.ImportQr -> launchScan()
             Tag.Export -> launchFilePicker(exportFilePicker, generateFilename())
         }
     }
@@ -103,6 +124,29 @@ class ImportExportFragment : Fragment() {
         } catch (e: ActivityNotFoundException) {
             showMsg("Error: No app found to choose backup file.")
             Log.e("ImportExport", "Error: No app found to choose backup file.", e)
+        }
+    }
+
+    private fun launchScan() {
+        val options = ScanOptions()
+                .setDesiredBarcodeFormats(ScanOptions.QR_CODE)
+                .setPrompt(getString(R.string.title_import_qr))
+        try {
+            scanCode.launch(options)
+        } catch (e: ActivityNotFoundException) {
+            showMsg(getString(R.string.err_no_scan_app))
+            Log.e(javaClass.simpleName, "No app found to scan QR code.", e)
+        }
+    }
+
+    /**
+     * Handles an `AVNC:URI` decoded from a QR code.
+     */
+    private fun handleImportedUri(uri: Uri) {
+        when (uri.scheme) {
+            "vnc" -> startActivity(Intent(Intent.ACTION_VIEW, uri))
+            "file", "http", "https" -> viewModel.import(uri)
+            else -> showMsg(getString(R.string.err_unsupported_qr_uri))
         }
     }
 

--- a/app/src/main/java/com/gaurav/avnc/ui/prefs/QrDialog.kt
+++ b/app/src/main/java/com/gaurav/avnc/ui/prefs/QrDialog.kt
@@ -51,7 +51,7 @@ class QrDialog : DialogFragment() {
         } catch (e: WriterException) {
             Log.e(QrDialog::class.simpleName, "Failed to generate QR code", e)
             return dialogBuilder(title)
-                    .setMessage(R.string.err_qr_export_failed)
+                    .setMessage("${getString(R.string.err_qr_export_failed)} ${e.localizedMessage}")
                     .create()
         }
 

--- a/app/src/main/java/com/gaurav/avnc/ui/prefs/QrDialog.kt
+++ b/app/src/main/java/com/gaurav/avnc/ui/prefs/QrDialog.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2022  Gaurav Ujjwal.
+ *
+ * SPDX-License-Identifier:  GPL-3.0-or-later
+ *
+ * See COPYING.txt for more details.
+ */
+
+package com.gaurav.avnc.ui.prefs
+
+import android.app.Dialog
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.os.Bundle
+import android.util.Log
+import android.widget.ImageView
+import androidx.core.graphics.createBitmap
+import androidx.core.graphics.set
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.FragmentManager
+import com.gaurav.avnc.R
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.WriterException
+import com.google.zxing.qrcode.QRCodeWriter
+
+/**
+ * [DialogFragment] that displays a QR code.
+ */
+class QrDialog : DialogFragment() {
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val title = requireArguments().getCharSequence(ARG_TITLE)
+        val data = requireArguments().getCharSequence(ARG_DATA) ?: ""
+
+        val image = try {
+            QRCodeWriter()
+                    .encode(data.toString(), BarcodeFormat.QR_CODE, 512, 512)
+                    .let { matrix ->
+                        createBitmap(matrix.width, matrix.height, Bitmap.Config.RGB_565).apply {
+                            for (x in 0 until matrix.width)
+                                for (y in 0 until matrix.height)
+                                    this[x, y] = if (matrix[x, y]) Color.BLACK else Color.WHITE
+                        }
+                    }.let { bitmap ->
+                        ImageView(requireContext()).apply {
+                            setImageBitmap(bitmap)
+                            adjustViewBounds = true
+                        }
+                    }
+        } catch (e: WriterException) {
+            Log.e(QrDialog::class.simpleName, "Failed to generate QR code", e)
+            return dialogBuilder(title)
+                    .setMessage(R.string.err_qr_export_failed)
+                    .create()
+        }
+
+        return dialogBuilder(title)
+                .setView(image)
+                .create()
+    }
+
+    private fun dialogBuilder(title: CharSequence?): MaterialAlertDialogBuilder =
+            MaterialAlertDialogBuilder(requireContext())
+                    .setTitle(title)
+                    .setPositiveButton(android.R.string.ok, null)
+
+    companion object {
+        private const val ARG_TITLE = "title"
+        private const val ARG_DATA = "data"
+
+        /**
+         * Shows a [QrDialog] with the given [title],
+         * embedding a QR code with the given [data].
+         */
+        fun show(manager: FragmentManager, title: CharSequence, data: CharSequence): Unit =
+                QrDialog().apply {
+                    arguments = Bundle(2).apply {
+                        putCharSequence(ARG_TITLE, title)
+                        putCharSequence(ARG_DATA, data)
+                    }
+                }.show(manager, null)
+    }
+
+}

--- a/app/src/main/java/com/gaurav/avnc/util/ConfirmDialog.kt
+++ b/app/src/main/java/com/gaurav/avnc/util/ConfirmDialog.kt
@@ -1,0 +1,65 @@
+package com.gaurav.avnc.util
+
+import android.app.Dialog
+import android.os.Bundle
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.FragmentManager
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+
+/**
+ * Shows a dialog that asks the user to confirm an action.
+ *
+ * When confirmed, a fragment result is delivered on the specified key
+ * (via [FragmentManager.setFragmentResult]).
+ * The host must register a listener with [FragmentManager.setFragmentResultListener].
+ *
+ * All state (title, message, result) is stored in arguments, so the dialog is
+ * safe to be destroyed and recreated by the OS.
+ */
+class ConfirmDialog : DialogFragment() {
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val args = requireArguments()
+        val title = args.getCharSequence(ARG_TITLE)
+        val msg = args.getCharSequence(ARG_MSG)
+        val requestKey = args.getString(ARG_REQUEST_KEY) ?: throw Exception("Missing request key")
+        val result = args.getBundle(ARG_RESULT) ?: Bundle()
+
+        return MaterialAlertDialogBuilder(requireContext())
+                .setTitle(title)
+                .setMessage(msg)
+                .setPositiveButton(android.R.string.ok) { _, _ ->
+                    parentFragmentManager.setFragmentResult(requestKey, result)
+                }
+                .setNegativeButton(android.R.string.cancel) { _, _ -> /* Let it dismiss */ }
+                .create()
+    }
+
+    companion object {
+        private const val ARG_TITLE = "title"
+        private const val ARG_MSG = "msg"
+        private const val ARG_REQUEST_KEY = "request_key"
+        private const val ARG_RESULT = "result"
+
+        /**
+         * Shows a [ConfirmDialog] with the given [title] and [msg].
+         * When confirmed, a fragment result containing [result] is delivered on
+         * [requestKey] to the host's [FragmentManager].
+         */
+        fun show(
+                manager: FragmentManager,
+                requestKey: String,
+                title: CharSequence,
+                msg: CharSequence,
+                result: Bundle = Bundle(),
+        ): Unit = ConfirmDialog().apply {
+            arguments = Bundle(4).apply {
+                putCharSequence(ARG_TITLE, title)
+                putCharSequence(ARG_MSG, msg)
+                putString(ARG_REQUEST_KEY, requestKey)
+                putBundle(ARG_RESULT, result)
+            }
+        }.show(manager, null)
+    }
+
+}

--- a/app/src/main/java/com/gaurav/avnc/util/QrCode.kt
+++ b/app/src/main/java/com/gaurav/avnc/util/QrCode.kt
@@ -1,0 +1,30 @@
+package com.gaurav.avnc.util
+
+import android.net.Uri as URI
+import androidx.core.net.toUri
+
+object QrCode {
+
+    class InvalidQrCodeException : Exception()
+
+    sealed class Content {
+        data class Json(val json: String) : Content()
+        data class Uri(val uri: URI) : Content()
+    }
+
+    /**
+     * Parses AVNC QR content of the form `AVNC:TYPE[:option]*;<payload>`.
+     */
+    fun decode(content: String): Content {
+        val sep = content.indexOf(';')
+        val header = if (sep >= 0) content.substring(0, sep) else content
+        val payload = if (sep >= 0) content.substring(sep + 1) else ""
+
+        return when {
+            header == "AVNC:DATA" || header.startsWith("AVNC:DATA:") -> Content.Json(payload)
+            header == "AVNC:URI" || header.startsWith("AVNC:URI:") -> Content.Uri(payload.toUri())
+            else -> throw InvalidQrCodeException()
+        }
+    }
+
+}

--- a/app/src/main/java/com/gaurav/avnc/util/QrCode.kt
+++ b/app/src/main/java/com/gaurav/avnc/util/QrCode.kt
@@ -27,4 +27,9 @@ object QrCode {
         }
     }
 
+    /**
+     * Encodes the given [json] as AVNC QR content of the form `AVNC:DATA;<json>`.
+     */
+    fun encode(json: String): String = "AVNC:DATA;$json"
+
 }

--- a/app/src/main/java/com/gaurav/avnc/viewmodel/PrefsViewModel.kt
+++ b/app/src/main/java/com/gaurav/avnc/viewmodel/PrefsViewModel.kt
@@ -66,20 +66,10 @@ class PrefsViewModel(app: Application) : BaseViewModel(app) {
         val exportSettings = exportSettings.isTrue
         val exportProfiles = exportProfiles.isTrue
         val exportSecrets = exportSecrets.isTrue && exportProfiles
-        debugCheck(exportSettings || exportProfiles)
 
         launchIO {
             runCatching {
-                // Serialize
-                val data = Container(
-                        profiles = if (exportProfiles) serverProfileDao.getList() else emptyList(),
-                        preferences = if (exportSettings) collectPreferences() else emptyMap()
-                )
-
-                if (!exportSecrets)
-                    scrubSecrets(data.profiles)
-
-                val json = serializer.encodeToString(data)
+                val json = exportJson(exportProfiles, exportSettings, exportSecrets)
 
                 // Write out
                 app.contentResolver.openOutputStream(uri)?.use { stream ->
@@ -107,33 +97,61 @@ class PrefsViewModel(app: Application) : BaseViewModel(app) {
                     stream.reader().use { it.readText() }
                 } ?: throw IOException("Unable to read the file.")
 
-                // Deserialize
-                val data = serializer.decodeFromString<Container>(json)
-
-                //This is where migrations would be applied (if required in future)
-
-                //Update database
-                if (data.profiles.isNotEmpty()) {
-                    if (deleteCurrentServers) {
-                        db.withTransaction {
-                            serverProfileDao.deleteAll()
-                            serverProfileDao.save(data.profiles)
-                        }
-                    } else {
-                        //Reset IDs so that they don't conflict with saved profiles
-                        data.profiles.forEach { it.ID = 0 }
-                        serverProfileDao.save(data.profiles)
-                    }
-                }
-
-                // Replay app preferences (best-effort, unknown keys are ignored)
-                applyPreferences(data.preferences)
+                importJson(json, deleteCurrentServers)
 
                 return@runCatching app.getString(R.string.msg_imported)
             }.let {
                 importExportFinishedEvent.fireAsync(it)
             }
         }
+    }
+
+    /**
+     * Serializes current profiles or settings into a backup JSON string.
+     */
+    private suspend fun exportJson(
+            exportProfiles: Boolean,
+            exportSettings: Boolean,
+            exportSecrets: Boolean,
+    ): String {
+        debugCheck(exportSettings || exportProfiles)
+
+        // Serialize
+        val data = Container(
+                profiles = if (exportProfiles) serverProfileDao.getList() else emptyList(),
+                preferences = if (exportSettings) collectPreferences() else emptyMap()
+        )
+
+        if (!exportSecrets)
+            scrubSecrets(data.profiles)
+
+        return serializer.encodeToString(data)
+    }
+
+    /**
+     * Deserializes given backup JSON and updates the database.
+     */
+    private suspend fun importJson(json: String, deleteCurrentServers: Boolean) {
+        // Deserialize
+        val data = serializer.decodeFromString<Container>(json)
+
+        //This is where migrations would be applied (if required in future)
+
+        if (data.profiles.isNotEmpty()) {
+            if (deleteCurrentServers) {
+                db.withTransaction {
+                    serverProfileDao.deleteAll()
+                    serverProfileDao.save(data.profiles)
+                }
+            } else {
+                //Reset IDs so that they don't conflict with saved profiles
+                data.profiles.forEach { it.ID = 0 }
+                serverProfileDao.save(data.profiles)
+            }
+        }
+
+        // Replay app preferences (best-effort, unknown keys are ignored)
+        applyPreferences(data.preferences)
     }
 
     /**

--- a/app/src/main/java/com/gaurav/avnc/viewmodel/PrefsViewModel.kt
+++ b/app/src/main/java/com/gaurav/avnc/viewmodel/PrefsViewModel.kt
@@ -25,6 +25,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
+import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.net.HttpURLConnection
 import java.net.URI
@@ -36,6 +37,7 @@ class PrefsViewModel(app: Application) : BaseViewModel(app) {
 
     private companion object {
         const val TIMEOUT_MS = 10_000
+        const val MAX_RESPONSE_BYTES = 1024 * 1024
     }
 
     /**************************************************************************
@@ -124,7 +126,16 @@ class PrefsViewModel(app: Application) : BaseViewModel(app) {
             if (code !in 200..299)
                 throw IOException("Unable to read the file: HTTP $code")
             return connection.inputStream.use { stream ->
-                stream.reader().use { it.readText() }
+                val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                val output = ByteArrayOutputStream()
+                while (true) {
+                    val n = stream.read(buffer)
+                    if (n < 0) break
+                    if (output.size() + n > MAX_RESPONSE_BYTES)
+                        throw IOException(app.getString(R.string.err_import_too_large))
+                    output.write(buffer, 0, n)
+                }
+                output.toString(Charsets.UTF_8.name())
             }
         } finally {
             connection.disconnect()

--- a/app/src/main/java/com/gaurav/avnc/viewmodel/PrefsViewModel.kt
+++ b/app/src/main/java/com/gaurav/avnc/viewmodel/PrefsViewModel.kt
@@ -63,19 +63,15 @@ class PrefsViewModel(app: Application) : BaseViewModel(app) {
      * Exports data to given [uri].
      */
     fun export(uri: Uri) {
-        launchIO {
-            runCatching {
-                val json = exportJson()
+        launchImportExport {
+            val json = exportJson()
 
-                // Write out
-                app.contentResolver.openOutputStream(uri)?.use { stream ->
-                    stream.writer().use { it.write(json) }
-                } ?: throw IOException("Unable to write the file.")
+            // Write out
+            app.contentResolver.openOutputStream(uri)?.use { stream ->
+                stream.writer().use { it.write(json) }
+            } ?: throw IOException("Unable to write the file.")
 
-                return@runCatching app.getString(R.string.msg_exported)
-            }.let {
-                importExportFinishedEvent.fireAsync(it)
-            }
+            app.getString(R.string.msg_exported)
         }
     }
 
@@ -84,14 +80,10 @@ class PrefsViewModel(app: Application) : BaseViewModel(app) {
      * for export, e.g. via QR code.
      */
     fun export(jsonDestination : MutableLiveData<String>) {
-        launchIO {
-            runCatching {
-                val json = exportJson()
-                jsonDestination.postValue(json)
-                return@runCatching app.getString(R.string.msg_exported)
-            }.let {
-                importExportFinishedEvent.fireAsync(it)
-            }
+        launchImportExport {
+            val json = exportJson()
+            jsonDestination.postValue(json)
+            app.getString(R.string.msg_exported)
         }
     }
 
@@ -99,19 +91,14 @@ class PrefsViewModel(app: Application) : BaseViewModel(app) {
      * Imports data from given [uri].
      */
     fun import(uri: Uri) {
-        launchIO {
-            runCatching {
+        launchImportExport {
+            val json = app.contentResolver.openInputStream(uri)?.use { stream ->
+                stream.reader().use { it.readText() }
+            } ?: throw IOException("Unable to read the file.")
 
-                val json = app.contentResolver.openInputStream(uri)?.use { stream ->
-                    stream.reader().use { it.readText() }
-                } ?: throw IOException("Unable to read the file.")
+            importJson(json)
 
-                importJson(json)
-
-                return@runCatching app.getString(R.string.msg_imported)
-            }.let {
-                importExportFinishedEvent.fireAsync(it)
-            }
+            app.getString(R.string.msg_imported)
         }
     }
 
@@ -119,10 +106,20 @@ class PrefsViewModel(app: Application) : BaseViewModel(app) {
      * Imports data from given JSON string (e.g. read off a QR code).
      */
     fun import(json: String) {
+        launchImportExport {
+            importJson(json)
+            app.getString(R.string.msg_imported)
+        }
+    }
+
+    /**
+     * Runs an import/export operation on a background thread and fires
+     * [importExportFinishedEvent] with its [Result].
+     */
+    private fun launchImportExport(block: suspend () -> String) {
         launchIO {
             runCatching {
-                importJson(json)
-                return@runCatching app.getString(R.string.msg_imported)
+                block()
             }.let {
                 importExportFinishedEvent.fireAsync(it)
             }

--- a/app/src/main/java/com/gaurav/avnc/viewmodel/PrefsViewModel.kt
+++ b/app/src/main/java/com/gaurav/avnc/viewmodel/PrefsViewModel.kt
@@ -26,12 +26,17 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
 import java.io.IOException
+import java.net.HttpURLConnection
+import java.net.URI
 
 /**
  * Viewmodel for preferences activity.
  */
 class PrefsViewModel(app: Application) : BaseViewModel(app) {
 
+    private companion object {
+        const val TIMEOUT_MS = 10_000
+    }
 
     /**************************************************************************
      * Import/Export
@@ -92,13 +97,37 @@ class PrefsViewModel(app: Application) : BaseViewModel(app) {
      */
     fun import(uri: Uri) {
         launchImportExport {
-            val json = app.contentResolver.openInputStream(uri)?.use { stream ->
-                stream.reader().use { it.readText() }
-            } ?: throw IOException("Unable to read the file.")
+            val json = when (uri.scheme) {
+                "http", "https" -> readFromNetwork(uri)
+                else -> app.contentResolver.openInputStream(uri)?.use { stream ->
+                    stream.reader().use { it.readText() }
+                } ?: throw IOException("Unable to read the file.")
+            }
 
             importJson(json)
 
             app.getString(R.string.msg_imported)
+        }
+    }
+
+    /**
+     * Reads the entire body of an http/https [uri] into a String.
+     */
+    private fun readFromNetwork(uri: Uri): String {
+        val connection = (URI(uri.toString()).toURL().openConnection() as HttpURLConnection).apply {
+            connectTimeout = TIMEOUT_MS
+            readTimeout = TIMEOUT_MS
+            requestMethod = "GET"
+        }
+        try {
+            val code = connection.responseCode
+            if (code !in 200..299)
+                throw IOException("Unable to read the file: HTTP $code")
+            return connection.inputStream.use { stream ->
+                stream.reader().use { it.readText() }
+            }
+        } finally {
+            connection.disconnect()
         }
     }
 

--- a/app/src/main/java/com/gaurav/avnc/viewmodel/PrefsViewModel.kt
+++ b/app/src/main/java/com/gaurav/avnc/viewmodel/PrefsViewModel.kt
@@ -63,13 +63,9 @@ class PrefsViewModel(app: Application) : BaseViewModel(app) {
      * Exports data to given [uri].
      */
     fun export(uri: Uri) {
-        val exportSettings = exportSettings.isTrue
-        val exportProfiles = exportProfiles.isTrue
-        val exportSecrets = exportSecrets.isTrue && exportProfiles
-
         launchIO {
             runCatching {
-                val json = exportJson(exportProfiles, exportSettings, exportSecrets)
+                val json = exportJson()
 
                 // Write out
                 app.contentResolver.openOutputStream(uri)?.use { stream ->
@@ -83,13 +79,26 @@ class PrefsViewModel(app: Application) : BaseViewModel(app) {
         }
     }
 
+    /**
+     * Exports data as JSON and posts the result on [jsonDestination],
+     * for export, e.g. via QR code.
+     */
+    fun export(jsonDestination : MutableLiveData<String>) {
+        launchIO {
+            runCatching {
+                val json = exportJson()
+                jsonDestination.postValue(json)
+                return@runCatching app.getString(R.string.msg_exported)
+            }.let {
+                importExportFinishedEvent.fireAsync(it)
+            }
+        }
+    }
 
     /**
      * Imports data from given [uri].
      */
     fun import(uri: Uri) {
-        val deleteCurrentServers = deleteCurrentServerBeforeImport.isTrue
-
         launchIO {
             runCatching {
 
@@ -97,8 +106,22 @@ class PrefsViewModel(app: Application) : BaseViewModel(app) {
                     stream.reader().use { it.readText() }
                 } ?: throw IOException("Unable to read the file.")
 
-                importJson(json, deleteCurrentServers)
+                importJson(json)
 
+                return@runCatching app.getString(R.string.msg_imported)
+            }.let {
+                importExportFinishedEvent.fireAsync(it)
+            }
+        }
+    }
+
+    /**
+     * Imports data from given JSON string (e.g. read off a QR code).
+     */
+    fun import(json: String) {
+        launchIO {
+            runCatching {
+                importJson(json)
                 return@runCatching app.getString(R.string.msg_imported)
             }.let {
                 importExportFinishedEvent.fireAsync(it)
@@ -109,11 +132,10 @@ class PrefsViewModel(app: Application) : BaseViewModel(app) {
     /**
      * Serializes current profiles or settings into a backup JSON string.
      */
-    private suspend fun exportJson(
-            exportProfiles: Boolean,
-            exportSettings: Boolean,
-            exportSecrets: Boolean,
-    ): String {
+    private suspend fun exportJson(): String {
+        val exportSettings = exportSettings.isTrue
+        val exportProfiles = exportProfiles.isTrue
+        val exportSecrets = exportSecrets.isTrue && exportProfiles
         debugCheck(exportSettings || exportProfiles)
 
         // Serialize
@@ -131,7 +153,9 @@ class PrefsViewModel(app: Application) : BaseViewModel(app) {
     /**
      * Deserializes given backup JSON and updates the database.
      */
-    private suspend fun importJson(json: String, deleteCurrentServers: Boolean) {
+    private suspend fun importJson(json: String) {
+        val deleteCurrentServers = deleteCurrentServerBeforeImport.isTrue
+
         // Deserialize
         val data = serializer.decodeFromString<Container>(json)
 

--- a/app/src/main/res/drawable/ic_qr_code.xml
+++ b/app/src/main/res/drawable/ic_qr_code.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="24dp"
+  android:height="24dp"
+  android:viewportWidth="24"
+  android:viewportHeight="24">
+  <path
+    android:fillColor="?colorOnSurface"
+    android:pathData="M4,4h7v7H4V4zM6,6v3h3V6H6zM4,13h7v7H4V13zM6,15v3h3v-3H6zM13,4h7v7h-7V4zM19,6h-4v3h4V6zM13,13h2v2h-2V13zM17,13h2v2h-2V13zM13,17h2v2h-2V17zM17,17h2v2h-2V17z" />
+</vector>

--- a/app/src/main/res/layout/fragment_import_export.xml
+++ b/app/src/main/res/layout/fragment_import_export.xml
@@ -67,8 +67,8 @@
             android:enabled="@{viewModel.exportSettings || viewModel.exportProfiles}"
             android:paddingHorizontal="30dp"
             android:paddingVertical="@dimen/padding_normal"
-            android:text="@string/title_export"
-            app:icon="@drawable/ic_upload" />
+            android:text="@string/title_export_file"
+            app:icon="@drawable/ic_file" />
 
         <Space
             android:layout_width="0dp"
@@ -111,8 +111,8 @@
             android:layout_height="wrap_content"
             android:paddingHorizontal="30dp"
             android:paddingVertical="@dimen/padding_normal"
-            android:text="@string/title_import"
-            app:icon="@drawable/ic_download" />
+            android:text="@string/title_import_file"
+            app:icon="@drawable/ic_file" />
 
         <Space
             android:layout_width="0dp"

--- a/app/src/main/res/layout/fragment_import_export.xml
+++ b/app/src/main/res/layout/fragment_import_export.xml
@@ -24,6 +24,18 @@
         android:paddingTop="5dp"
         android:weightSum="1">
 
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/title_export"
+            style="@style/PreferenceCategoryTitleTextStyle" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginBottom="@dimen/padding_small"
+            android:background="@color/colorBorder" />
+
         <CheckBox
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -66,6 +78,19 @@
         <View
             android:layout_width="match_parent"
             android:layout_height="2dp"
+            android:layout_marginBottom="@dimen/padding_small"
+            android:background="@color/colorBorder" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/title_import"
+            style="@style/PreferenceCategoryTitleTextStyle" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginBottom="@dimen/padding_small"
             android:background="@color/colorBorder" />
 
         <CheckBox

--- a/app/src/main/res/layout/fragment_import_export.xml
+++ b/app/src/main/res/layout/fragment_import_export.xml
@@ -73,6 +73,21 @@
         <Space
             android:layout_width="0dp"
             android:layout_height="0dp"
+            android:layout_weight=".1" />
+
+        <Button
+            android:id="@+id/export_qr_btn"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="@{viewModel.exportSettings || viewModel.exportProfiles}"
+            android:paddingHorizontal="30dp"
+            android:paddingVertical="@dimen/padding_normal"
+            android:text="@string/title_export_qr"
+            app:icon="@drawable/ic_qr_code" />
+
+        <Space
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             android:layout_weight=".3" />
 
         <View

--- a/app/src/main/res/layout/fragment_import_export.xml
+++ b/app/src/main/res/layout/fragment_import_export.xml
@@ -88,5 +88,19 @@
             android:paddingVertical="@dimen/padding_normal"
             android:text="@string/title_import"
             app:icon="@drawable/ic_download" />
+
+        <Space
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_weight=".1" />
+
+        <Button
+            android:id="@+id/import_qr_btn"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingHorizontal="30dp"
+            android:paddingVertical="@dimen/padding_normal"
+            android:text="@string/title_import_qr"
+            app:icon="@drawable/ic_qr_code" />
     </LinearLayout>
 </layout>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -47,6 +47,7 @@
     <string name="err_invalid_qr_code">Ce n’est pas un code QR AVNC.</string>
     <string name="err_qr_export_failed">Échec de la génération du code QR :</string>
     <string name="err_unsupported_qr_uri">URI non prise en charge ou invalide.</string>
+    <string name="msg_confirm_import_uri">Importer depuis l’URI suivante ?</string>
     <string name="msg_invalid_key_file">Fichier de clé privée invalide</string>
     <string name="msg_invalid_vnc_uri">URI VNC invalide</string>
     <string name="msg_copied_to_clipboard">Copié</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -12,7 +12,9 @@
     <string name="title_settings">Paramètres</string>
     <string name="title_vnc_login">Connexion VNC</string>
     <string name="title_export">Exporter</string>
+    <string name="title_export_file">Export vers un fichier</string>
     <string name="title_import">Importer</string>
+    <string name="title_import_file">Importer un fichier</string>
     <string name="title_import_qr">Scanner un code QR</string>
     <string name="title_view_only_mode">Visualisation uniquement</string>
     <string name="title_remember">Mémoriser</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -44,7 +44,7 @@
     <string name="msg_exported">Exporté</string>
     <string name="msg_export_auth_required">Authentifiez-vous pour exporter des serveurs</string>
     <string name="err_invalid_qr_code">Ce n’est pas un code QR AVNC.</string>
-    <string name="err_qr_export_failed">Échec de la génération du code QR.</string>
+    <string name="err_qr_export_failed">Échec de la génération du code QR :</string>
     <string name="err_unsupported_qr_uri">URI non prise en charge ou invalide.</string>
     <string name="msg_invalid_key_file">Fichier de clé privée invalide</string>
     <string name="msg_invalid_vnc_uri">URI VNC invalide</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -13,6 +13,7 @@
     <string name="title_vnc_login">Connexion VNC</string>
     <string name="title_export">Exporter</string>
     <string name="title_export_file">Export vers un fichier</string>
+    <string name="title_export_qr">Afficher le code QR</string>
     <string name="title_import">Importer</string>
     <string name="title_import_file">Importer un fichier</string>
     <string name="title_import_qr">Scanner un code QR</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -44,7 +44,6 @@
     <string name="msg_exported">Exporté</string>
     <string name="msg_export_auth_required">Authentifiez-vous pour exporter des serveurs</string>
     <string name="err_invalid_qr_code">Ce n’est pas un code QR AVNC.</string>
-    <string name="err_no_scan_app">Erreur : aucune application trouvée pour scanner un code QR.</string>
     <string name="err_qr_export_failed">Échec de la génération du code QR.</string>
     <string name="err_unsupported_qr_uri">URI non prise en charge ou invalide.</string>
     <string name="msg_invalid_key_file">Fichier de clé privée invalide</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -43,6 +43,7 @@
     <string name="msg_imported">Importé</string>
     <string name="msg_exported">Exporté</string>
     <string name="msg_export_auth_required">Authentifiez-vous pour exporter des serveurs</string>
+    <string name="err_import_too_large">Le fichier d\'import est trop gros (limite : 1 Mio).</string>
     <string name="err_invalid_qr_code">Ce n’est pas un code QR AVNC.</string>
     <string name="err_qr_export_failed">Échec de la génération du code QR :</string>
     <string name="err_unsupported_qr_uri">URI non prise en charge ou invalide.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -45,6 +45,7 @@
     <string name="msg_export_auth_required">Authentifiez-vous pour exporter des serveurs</string>
     <string name="err_invalid_qr_code">Ce n’est pas un code QR AVNC.</string>
     <string name="err_no_scan_app">Erreur : aucune application trouvée pour scanner un code QR.</string>
+    <string name="err_qr_export_failed">Échec de la génération du code QR.</string>
     <string name="err_unsupported_qr_uri">URI non prise en charge ou invalide.</string>
     <string name="msg_invalid_key_file">Fichier de clé privée invalide</string>
     <string name="msg_invalid_vnc_uri">URI VNC invalide</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -43,6 +43,9 @@
     <string name="msg_imported">Importé</string>
     <string name="msg_exported">Exporté</string>
     <string name="msg_export_auth_required">Authentifiez-vous pour exporter des serveurs</string>
+    <string name="err_invalid_qr_code">Ce n’est pas un code QR AVNC.</string>
+    <string name="err_no_scan_app">Erreur : aucune application trouvée pour scanner un code QR.</string>
+    <string name="err_unsupported_qr_uri">URI non prise en charge ou invalide.</string>
     <string name="msg_invalid_key_file">Fichier de clé privée invalide</string>
     <string name="msg_invalid_vnc_uri">URI VNC invalide</string>
     <string name="msg_copied_to_clipboard">Copié</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -13,6 +13,7 @@
     <string name="title_vnc_login">Connexion VNC</string>
     <string name="title_export">Exporter</string>
     <string name="title_import">Importer</string>
+    <string name="title_import_qr">Scanner un code QR</string>
     <string name="title_view_only_mode">Visualisation uniquement</string>
     <string name="title_remember">Mémoriser</string>
     <string name="title_hide_remote_cursor">Masquer le curseur distant</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,7 @@
     <string name="title_remember">Remember</string>
     <string name="title_export">Export</string>
     <string name="title_import">Import</string>
+    <string name="title_import_qr">Scan QR code</string>
     <string name="title_view_only_mode">View-only</string>
     <string name="title_connect_on_app_start">Auto-connect when app starts</string>
     <string name="title_enable_wol">Wake-on-LAN</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -107,6 +107,7 @@
     <string name="msg_saved">Saved</string>
     <string name="msg_done">Done</string>
     <string name="msg_export_auth_required">Authenticate to export servers</string>
+    <string name="err_import_too_large">Import file is too large (limit: 1 MiB).</string>
     <string name="err_invalid_qr_code">Invalid AVNC QR code.</string>
     <string name="err_qr_export_failed">Failed to generate QR code:</string>
     <string name="err_unsupported_qr_uri">Unsupported or invalid URI.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,7 +108,7 @@
     <string name="msg_done">Done</string>
     <string name="msg_export_auth_required">Authenticate to export servers</string>
     <string name="err_invalid_qr_code">Invalid AVNC QR code.</string>
-    <string name="err_qr_export_failed">Failed to generate QR code.</string>
+    <string name="err_qr_export_failed">Failed to generate QR code:</string>
     <string name="err_unsupported_qr_uri">Unsupported or invalid URI.</string>
     <string name="msg_required">Required</string>
     <string name="msg_invalid_mac_address">Invalid MAC address</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,7 @@
     <string name="title_remember">Remember</string>
     <string name="title_export">Export</string>
     <string name="title_export_file">Export to file</string>
+    <string name="title_export_qr">Display QR code</string>
     <string name="title_import">Import</string>
     <string name="title_import_file">Import file</string>
     <string name="title_import_qr">Scan QR code</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,7 +29,9 @@
     <string name="title_forget">Forget</string>
     <string name="title_remember">Remember</string>
     <string name="title_export">Export</string>
+    <string name="title_export_file">Export to file</string>
     <string name="title_import">Import</string>
+    <string name="title_import_file">Import file</string>
     <string name="title_import_qr">Scan QR code</string>
     <string name="title_view_only_mode">View-only</string>
     <string name="title_connect_on_app_start">Auto-connect when app starts</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,6 +111,7 @@
     <string name="err_invalid_qr_code">Invalid AVNC QR code.</string>
     <string name="err_qr_export_failed">Failed to generate QR code:</string>
     <string name="err_unsupported_qr_uri">Unsupported or invalid URI.</string>
+    <string name="msg_confirm_import_uri">Import from the following URI?</string>
     <string name="msg_required">Required</string>
     <string name="msg_invalid_mac_address">Invalid MAC address</string>
     <string name="msg_invalid_key_file">Invalid private key file</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,7 +108,6 @@
     <string name="msg_done">Done</string>
     <string name="msg_export_auth_required">Authenticate to export servers</string>
     <string name="err_invalid_qr_code">Invalid AVNC QR code.</string>
-    <string name="err_no_scan_app">Error: No app found to scan QR code.</string>
     <string name="err_qr_export_failed">Failed to generate QR code.</string>
     <string name="err_unsupported_qr_uri">Unsupported or invalid URI.</string>
     <string name="msg_required">Required</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -107,6 +107,9 @@
     <string name="msg_saved">Saved</string>
     <string name="msg_done">Done</string>
     <string name="msg_export_auth_required">Authenticate to export servers</string>
+    <string name="err_invalid_qr_code">Invalid AVNC QR code.</string>
+    <string name="err_no_scan_app">Error: No app found to scan QR code.</string>
+    <string name="err_unsupported_qr_uri">Unsupported or invalid URI.</string>
     <string name="msg_required">Required</string>
     <string name="msg_invalid_mac_address">Invalid MAC address</string>
     <string name="msg_invalid_key_file">Invalid private key file</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -109,6 +109,7 @@
     <string name="msg_export_auth_required">Authenticate to export servers</string>
     <string name="err_invalid_qr_code">Invalid AVNC QR code.</string>
     <string name="err_no_scan_app">Error: No app found to scan QR code.</string>
+    <string name="err_qr_export_failed">Failed to generate QR code.</string>
     <string name="err_unsupported_qr_uri">Unsupported or invalid URI.</string>
     <string name="msg_required">Required</string>
     <string name="msg_invalid_mac_address">Invalid MAC address</string>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2020  Gaurav Ujjwal.
+  ~
+  ~ SPDX-License-Identifier:  GPL-3.0-or-later
+  ~
+  ~ See COPYING.txt for more details.
+  -->
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true" />
+</network-security-config>


### PR DESCRIPTION
This PR adds a "Scan QR code" and a "Display QR code" to the Import/Export screen.

Solves #385.

<img width="360" height="800" alt="AVNC screenshot" src="https://github.com/user-attachments/assets/15dfbc31-8c80-4e39-89b9-0a7ad9b55885" />

# QR code spec:

    "AVNC" colon <type> [ colon <option> ]* semi-colon <payload>.

 - *type* is either "DATA" or "URI"
 - *option* MUST NOT contain any colon or semi-colon
 - when *type* is "DATA", *payload* is a raw JSON exported configuration.
 - when *type* is "URI", *payload* is a URL pointing to a JSON exported configuration.

E.g.:
 - `AVNC:URI;https://example.com/avnc.json`
 - `AVNC:DATA;{"profiles":[{"ID":1,"name":"Server","host":"vnc.example.com"},{"ID":2,"name":"Work PC","host":"work-pc.example.com"}]}`